### PR TITLE
Add grade-level tail concentration analysis

### DIFF
--- a/Analysis/17_tail_concentration_by_level.R
+++ b/Analysis/17_tail_concentration_by_level.R
@@ -1,0 +1,158 @@
+# 17_tail_concentration_by_level.R
+# Computes Pareto concentration metrics by school level and setting.
+# Scans available parquet files in data-stage/ to ensure the correct
+# suspension and feature datasets are used.
+
+suppressPackageStartupMessages({
+  library(arrow)
+  library(dplyr)
+  library(stringr)
+  library(janitor)
+  library(here)
+  library(purrr)
+  library(readr)
+})
+
+# ---------------------------------------------------------------------------
+# Locate input parquet files
+# ---------------------------------------------------------------------------
+DATA_STAGE <- here("data-stage")
+
+# Required columns for the core suspension dataset
+req_cols <- c(
+  "school_code", "academic_year", "cumulative_enrollment",
+  "total_suspensions", "unduplicated_count_of_students_suspended_total"
+)
+
+# Find the first susp_v*.parquet file containing all required columns
+susp_files <- list.files(DATA_STAGE, pattern = "^susp_v[0-9]+\\.parquet$", full.names = TRUE)
+INPUT_PATH <- NULL
+for (f in susp_files) {
+  cols <- names(read_parquet(f, as_data_frame = FALSE))
+  if (all(req_cols %in% cols)) {
+    INPUT_PATH <- f
+    message("Using suspension data: ", basename(f))
+    break
+  } else {
+    message("Skipping ", basename(f), ": missing columns")
+  }
+}
+if (is.null(INPUT_PATH)) stop("No susp_v*.parquet file with all required columns found.")
+
+# Locate feature file for level/setting
+V6_FEAT <- file.path(DATA_STAGE, "susp_v6_features.parquet")
+if (!file.exists(V6_FEAT)) {
+  stop("Missing susp_v6_features.parquet. Run R/22_build_v6_features.R first.")
+} else {
+  message("Using features: ", basename(V6_FEAT))
+}
+
+# ---------------------------------------------------------------------------
+# Load and clean data
+# ---------------------------------------------------------------------------
+MEASURE <- "total_susp"                 # or "undup_susp" for unduplicated
+TOP_PCT <- c(0.05, 0.10, 0.20)          # Top share cutoffs
+
+# Helper to compute shares safely
+safe_div <- function(n, d) ifelse(is.na(d) | d == 0, NA_real_, n / d)
+
+# Helper to compute Pareto shares for a grouped data frame
+pareto_shares <- function(df, top_ps = TOP_PCT) {
+  n_schools <- n_distinct(df$school_id)
+  if (n_schools == 0) return(tibble())
+
+  df_sorted <- df %>%
+    group_by(school_id, school_name, enrollment) %>%
+    summarise(measure = sum(measure, na.rm = TRUE), .groups = "drop") %>%
+    arrange(desc(measure)) %>%
+    mutate(
+      rank          = row_number(),
+      cum_measure   = cumsum(measure),
+      total_measure = sum(measure, na.rm = TRUE),
+      share_cum     = safe_div(cum_measure, total_measure)
+    )
+
+  map_dfr(top_ps, function(p) {
+    cutoff_n <- max(1, floor(p * n_schools))
+    df_sorted %>%
+      slice(1:cutoff_n) %>%
+      summarise(
+        top_schools   = cutoff_n,
+        total_schools = n_schools,
+        top_share     = safe_div(sum(measure, na.rm = TRUE), df_sorted$total_measure[1])
+      ) %>%
+      mutate(top_pct = p)
+  })
+}
+
+# Load suspension data and restrict to Total/All Students
+raw <- read_parquet(INPUT_PATH) %>% clean_names()
+
+susp <- raw %>%
+  filter(str_to_lower(reporting_category) %in% c("total", "all students", "ta")) %>%
+  transmute(
+    school_id   = school_code,
+    year        = academic_year,
+    enrollment  = as.numeric(cumulative_enrollment),
+    total_susp  = as.numeric(total_suspensions),
+    undup_susp  = as.numeric(unduplicated_count_of_students_suspended_total),
+    measure     = if (MEASURE == "undup_susp") undup_susp else total_susp
+  ) %>%
+  mutate(year_num = as.integer(str_sub(year, 1, 4))) %>%
+  filter(!is.na(year_num), enrollment > 0, !is.na(measure))
+
+# Add school name if present
+if ("school_name" %in% names(raw)) {
+  susp <- susp %>% mutate(school_name = raw$school_name)
+} else {
+  susp <- susp %>% mutate(school_name = school_id)
+}
+
+# Load features for level and setting
+feat <- read_parquet(V6_FEAT) %>% clean_names() %>%
+  transmute(
+    school_code = as.character(school_code),
+    year_char   = as.character(year),
+    is_traditional,
+    school_type
+  )
+
+# Join features and map fields
+susp_feat <- susp %>%
+  left_join(feat, by = c("school_id" = "school_code", "year" = "year_char")) %>%
+  mutate(
+    setting = ifelse(is.na(is_traditional) | !is_traditional, "Non-traditional", "Traditional"),
+    level   = coalesce(school_type, "Other")
+  )
+
+# ---------------------------------------------------------------------------
+# Pareto shares by year × level × setting
+# ---------------------------------------------------------------------------
+ps_y_ls <- susp_feat %>%
+  filter(!is.na(level), !is.na(setting)) %>%
+  group_by(year_num, level, setting) %>%
+  group_modify(~pareto_shares(.x, TOP_PCT)) %>%
+  ungroup() %>%
+  mutate(measure_type = MEASURE)
+
+# Slide-ready labels
+ps_y_ls_lines <- ps_y_ls %>%
+  mutate(
+    top_label = paste0("Top ", scales::percent(top_pct)),
+    share_pct = scales::percent(top_share, accuracy = 0.1)
+  ) %>%
+  select(year_num, level, setting, top_label, share_pct, top_schools, total_schools, measure_type)
+
+# ---------------------------------------------------------------------------
+# Write outputs
+# ---------------------------------------------------------------------------
+RUN_TAG <- format(Sys.time(), "%Y%m%d_%H%M")
+OUT_DIR <- here("outputs", paste0("tail_concentration_by_level_", RUN_TAG))
+if (!dir.exists(OUT_DIR)) dir.create(OUT_DIR, recursive = TRUE)
+
+write_csv(ps_y_ls,       file.path(OUT_DIR, "pareto_shares_by_year_level_setting_raw.csv"))
+write_csv(ps_y_ls_lines, file.path(OUT_DIR, "pareto_shares_by_year_level_setting_slide_ready.csv"))
+
+message("Wrote outputs to ", OUT_DIR)
+
+# End of file

--- a/Analysis/README_tail_concentration_by_level.md
+++ b/Analysis/README_tail_concentration_by_level.md
@@ -1,0 +1,54 @@
+# Tail Concentration by School Level and Setting
+
+This analysis quantifies how suspensions are concentrated among schools and
+breaks out results by **school level** (elementary, middle, high, other) and
+**setting** (traditional vs. non‑traditional).  It produces Pareto share
+summaries so that, for example, you can identify what share of suspensions are
+accounted for by the top 5%, 10% or 20% of schools within each level/setting
+combination.
+
+## Data sources
+
+The script automatically scans the `data-stage/` directory and uses the first
+`susp_v*.parquet` file that contains the following fields:
+
+- `school_code`
+- `academic_year`
+- `cumulative_enrollment`
+- `total_suspensions`
+- `unduplicated_count_of_students_suspended_total`
+
+It also requires `susp_v6_features.parquet`, which supplies `is_traditional`
+and `school_type` so that schools can be tagged by setting and level.
+
+## Data cleaning
+
+1. Filter to "Total/All Students" records only.
+2. Convert counts and enrollment to numeric and drop rows with missing or
+   zero enrollment.
+3. Derive `year_num` from the academic year string.
+4. Join on `susp_v6_features.parquet` and map:
+   - `setting` = Traditional or Non‑traditional based on `is_traditional`
+   - `level`   = school type from `school_type` (elementary, middle, etc.)
+
+## Methodology
+
+For each year × level × setting group the script:
+
+1. Aggregates suspension counts per school.
+2. Sorts schools by the selected measure (`total_susp` by default).
+3. Computes the share of suspensions attributable to the top 5%, 10%, and 20%
+   of schools (Pareto shares).
+4. Emits both a raw dataset and a "slide‑ready" version with formatted
+   percentages.
+
+## Outputs
+
+Results are written to `outputs/tail_concentration_by_level_<timestamp>/`:
+
+- `pareto_shares_by_year_level_setting_raw.csv`
+- `pareto_shares_by_year_level_setting_slide_ready.csv`
+
+These files let you isolate concentration patterns for elementary, middle, and
+high schools in traditional and non‑traditional settings.
+

--- a/run_all.R
+++ b/run_all.R
@@ -28,6 +28,7 @@ run("Analysis/15a_emit_nonintersectional_exports.R")   # new companion script we
 # 3) Tail concentration analysis (reads outputs/data-merged/school_year_allstudents.parquet)
 #    name this file however you like; keep it under analysis/
 run("Analysis/16_tail_concentration_analysis.R")
+run("Analysis/17_tail_concentration_by_level.R")
 
 message("\n=== All done @ ", format(Sys.time(), usetz = TRUE), " ===")
 # End of file ----------------------------------------------------------------- 


### PR DESCRIPTION
## Summary
- add script to compute Pareto tail concentration by school level and setting
- document methodology and data cleaning steps for grade-level analysis
- include script in run_all pipeline

## Testing
- `R -q -e "lintr::lint('Analysis/17_tail_concentration_by_level.R')"` *(fails: command not found)*
- `Rscript Analysis/17_tail_concentration_by_level.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d47140848331a719ee4a38856f0b