### PR TITLE
refactor: centralize quartile labeling

### DIFF
--- a/Analysis/02_black_rates_by_quartiles.R
+++ b/Analysis/02_black_rates_by_quartiles.R
@@ -33,24 +33,12 @@ has_white_q <- any(grepl("^white_prop_q", names(v5)))
 if (!has_black_q) stop("Missing black_prop_q4/q_label in v5. Re-run R/04 and downstream.")
 if (!has_white_q) stop("Missing white_prop_q4/q_label in v5. Re-run revised R/04 and downstream.")
 
-# Use labels if present; otherwise build them from q4 integers
-get_q_label <- function(q4, race = c("Black","White")) {
-  race <- match.arg(race)
-  dplyr::case_when(
-    is.na(q4) ~ "Unknown",
-    q4 == 1L ~ paste0("Q1 (Lowest % ", race, ")"),
-    q4 == 2L ~ "Q2",
-    q4 == 3L ~ "Q3",
-    q4 == 4L ~ paste0("Q4 (Highest % ", race, ")")
-  )
-}
-
-# normalize label columns
+# normalize label columns using shared helper
 if (!"black_prop_q_label" %in% names(v5)) {
-  v5 <- v5 %>% mutate(black_prop_q_label = get_q_label(black_prop_q4, "Black"))
+  v5 <- v5 %>% mutate(black_prop_q_label = get_quartile_label(black_prop_q4, "Black"))
 }
 if (!"white_prop_q_label" %in% names(v5)) {
-  v5 <- v5 %>% mutate(white_prop_q_label = get_q_label(white_prop_q4, "White"))
+  v5 <- v5 %>% mutate(white_prop_q_label = get_quartile_label(white_prop_q4, "White"))
 }
 
 # Year order from TA rows
@@ -124,9 +112,9 @@ if (any(missing_quart$missing > 0)) {
 }
 ###################
 # common colors for quartiles
-quart_levels_blk <- c("Q1 (Lowest % Black)","Q2","Q3","Q4 (Highest % Black)")
-quart_levels_wht <- c("Q1 (Lowest % White)","Q2","Q3","Q4 (Highest % White)")
-pal_quart <- setNames(scales::hue_pal()(4), c("Q1 (Lowest % Black)","Q2","Q3","Q4 (Highest % Black)"))
+quart_levels_blk <- get_quartile_label(1:4, "Black")
+quart_levels_wht <- get_quartile_label(1:4, "White")
+pal_quart <- setNames(scales::hue_pal()(4), quart_levels_blk)
 
 # ---------- Plot helpers ----------
 
@@ -230,7 +218,7 @@ p_blk_reason <- plot_rb_reason_rates(blk_reasons,
 
 # ---------- WHITE quartiles ----------
 # reuse the same palette but re-level to white labels for clean legends
-pal_quart <- setNames(scales::hue_pal()(4), c("Q1 (Lowest % White)","Q2","Q3","Q4 (Highest % White)"))
+pal_quart <- setNames(scales::hue_pal()(4), quart_levels_wht)
 
 wht_totals <- wht_view$totals %>%
   mutate(quart = factor(quart, levels = quart_levels_wht))

--- a/Analysis/02b_black_rates_by_quartiles.R
+++ b/Analysis/02b_black_rates_by_quartiles.R
@@ -32,16 +32,9 @@ need_cols <- c(
 missing <- setdiff(need_cols, names(v5))
 if (length(missing)) stop("Missing in v5: ", paste(missing, collapse=", "))
 
-# ensure readable labels exist
-lbl_q <- function(q4, who) dplyr::case_when(
-  is.na(q4) ~ "Unknown",
-  q4 == 1L ~ paste0("Q1 (Lowest % ", who, ")"),
-  q4 == 2L ~ "Q2",
-  q4 == 3L ~ "Q3",
-  q4 == 4L ~ paste0("Q4 (Highest % ", who, ")")
-)
-if (!"black_prop_q_label" %in% names(v5))  v5 <- v5 %>% mutate(black_prop_q_label = lbl_q(black_prop_q4, "Black"))
-if (!"white_prop_q_label" %in% names(v5))  v5 <- v5 %>% mutate(white_prop_q_label = lbl_q(white_prop_q4, "White"))
+# ensure readable labels exist via shared helper
+if (!"black_prop_q_label" %in% names(v5))  v5 <- v5 %>% mutate(black_prop_q_label = get_quartile_label(black_prop_q4, "Black"))
+if (!"white_prop_q_label" %in% names(v5))  v5 <- v5 %>% mutate(white_prop_q_label = get_quartile_label(white_prop_q4, "White"))
 
 # year order (from TA rows with positive enrollment)
 year_levels <- v5 %>%
@@ -131,8 +124,8 @@ blk_share <- agg_rb_reason_shares(v5, "black_prop_q_label")
 wht_share <- agg_rb_reason_shares(v5, "white_prop_q_label")
 
 # drop Unknown quartile from plots
-keep_blk <- c("Q1 (Lowest % Black)","Q2","Q3","Q4 (Highest % Black)")
-keep_wht <- c("Q1 (Lowest % White)","Q2","Q3","Q4 (Highest % White)")
+keep_blk <- get_quartile_label(1:4, "Black")
+keep_wht <- get_quartile_label(1:4, "White")
 
 blk_totals      <- blk_view$totals       %>% filter(quart %in% keep_blk) %>% mutate(quart = factor(quart, levels = keep_blk))
 blk_reasons_rt  <- blk_view$reasons_rate %>% filter(quart %in% keep_blk) %>% mutate(quart = factor(quart, levels = keep_blk))

--- a/Analysis/02c_claude_black_rates_by_quartiles.R
+++ b/Analysis/02c_claude_black_rates_by_quartiles.R
@@ -13,13 +13,13 @@ source(here::here("R","utils_keys_filters.R"))
 theme_set(theme_minimal(base_size = 12))
 
 # Palettes (keep your originals)
-black_quartile_colors <- c(
-  "Q1 (Lowest % Black)" = "#FEE5D9", "Q2" = "#FCAE91",
-  "Q3" = "#FB6A4A", "Q4 (Highest % Black)" = "#CB181D"
+black_quartile_colors <- setNames(
+  c("#FEE5D9", "#FCAE91", "#FB6A4A", "#CB181D"),
+  get_quartile_label(1:4, "Black")
 )
-white_quartile_colors <- c(
-  "Q1 (Lowest % White)" = "#EFF3FF", "Q2" = "#BDD7E7",
-  "Q3" = "#6BAED6", "Q4 (Highest % White)" = "#08519C"
+white_quartile_colors <- setNames(
+  c("#EFF3FF", "#BDD7E7", "#6BAED6", "#08519C"),
+  get_quartile_label(1:4, "White")
 )
 
 # --- 2) Load + guards ---------------------------------------------------------
@@ -34,16 +34,9 @@ need_cols <- c("reporting_category","academic_year",
 missing <- setdiff(need_cols, names(v5))
 if (length(missing)) stop("Missing in v5: ", paste(missing, collapse=", "))
 
-# make sure readable quartile labels exist
-lbl_q <- function(q4, who) dplyr::case_when(
-  is.na(q4) ~ "Unknown",
-  q4 == 1L ~ paste0("Q1 (Lowest % ", who, ")"),
-  q4 == 2L ~ "Q2",
-  q4 == 3L ~ "Q3",
-  q4 == 4L ~ paste0("Q4 (Highest % ", who, ")")
-)
-if (!"black_prop_q_label" %in% names(v5)) v5 <- v5 %>% mutate(black_prop_q_label = lbl_q(black_prop_q4, "Black"))
-if (!"white_prop_q_label" %in% names(v5)) v5 <- v5 %>% mutate(white_prop_q_label = lbl_q(white_prop_q4, "White"))
+# make sure readable quartile labels exist using shared helper
+if (!"black_prop_q_label" %in% names(v5)) v5 <- v5 %>% mutate(black_prop_q_label = get_quartile_label(black_prop_q4, "Black"))
+if (!"white_prop_q_label" %in% names(v5)) v5 <- v5 %>% mutate(white_prop_q_label = get_quartile_label(white_prop_q4, "White"))
 
 # order x-axis by TA years that actually have enrollment
 year_levels <- v5 %>%

--- a/R/04_feature_black_prop_quartiles.R
+++ b/R/04_feature_black_prop_quartiles.R
@@ -62,21 +62,9 @@ rbw_q <- rb_rw_ta %>%
   mutate(
     black_prop_q4 = if_else(!is.na(prop_black), safe_ntile(prop_black, 4L), NA_integer_),
     white_prop_q4 = if_else(!is.na(prop_white), safe_ntile(prop_white, 4L), NA_integer_),
-    
-    black_prop_q_label = case_when(
-      is.na(black_prop_q4) ~ "Unknown",
-      black_prop_q4 == 1L  ~ "Q1 (Lowest % Black)",
-      black_prop_q4 == 2L  ~ "Q2",
-      black_prop_q4 == 3L  ~ "Q3",
-      black_prop_q4 == 4L  ~ "Q4 (Highest % Black)"
-    ),
-    white_prop_q_label = case_when(
-      is.na(white_prop_q4) ~ "Unknown",
-      white_prop_q4 == 1L  ~ "Q1 (Lowest % White)",
-      white_prop_q4 == 2L  ~ "Q2",
-      white_prop_q4 == 3L  ~ "Q3",
-      white_prop_q4 == 4L  ~ "Q4 (Highest % White)"
-    )
+
+    black_prop_q_label = get_quartile_label(black_prop_q4, "Black"),
+    white_prop_q_label = get_quartile_label(white_prop_q4, "White")
   ) %>%
   ungroup()
 
@@ -86,9 +74,9 @@ stopifnot(nrow(v3) == nrow(v2))
 
 # Freeze label order (optional but handy)
 v3$black_prop_q_label <- factor(v3$black_prop_q_label,
-                                levels = c("Q1 (Lowest % Black)","Q2","Q3","Q4 (Highest % Black)","Unknown"))
+                                levels = c(get_quartile_label(1:4, "Black"),"Unknown"))
 v3$white_prop_q_label <- factor(v3$white_prop_q_label,
-                                levels = c("Q1 (Lowest % White)","Q2","Q3","Q4 (Highest % White)","Unknown"))
+                                levels = c(get_quartile_label(1:4, "White"),"Unknown"))
 
 # Quick ping that special codes aren’t present (campus-only should already handle this)
 stopifnot(!any(stringr::str_detect(v3$cds_school, "0000000$|0000001$")))

--- a/R/24_rates_pooled_by_year_blackquartile.R
+++ b/R/24_rates_pooled_by_year_blackquartile.R
@@ -4,6 +4,8 @@ suppressPackageStartupMessages({
   library(scales); library(tidyr)
 })
 
+source(here::here("R","utils_keys_filters.R"))
+
 # ──────────────────────────────── Config / Paths ──────────────────────────────
 DATA_STAGE <- here("data-stage")                   # portable path
 V6F_PARQ   <- file.path(DATA_STAGE, "susp_v6_features.parquet")  # keys + flags
@@ -132,7 +134,7 @@ base_plot <- ggplot(sum_by, aes(x = year, y = pooled_rate, group = black_q, colo
   geom_point(size = 2.8) +
   scale_color_manual(values = quartile_cols,
                      breaks = c("Q1","Q2","Q3","Q4"),
-                     labels = c("Q1 (Lowest % Black)","Q2","Q3","Q4 (Highest % Black)")) +
+                     labels = get_quartile_label(1:4, "Black")) +
   scale_y_continuous(labels = percent_format(accuracy = 0.1),
                      expand = expansion(mult = c(0.05, 0.15))) +
   labs(

--- a/R/25_compare_white_vs_black_quartiles_swd.R
+++ b/R/25_compare_white_vs_black_quartiles_swd.R
@@ -6,6 +6,8 @@ suppressPackageStartupMessages({
   library(scales); library(tidyr); library(ggrepel)
 })
 
+source(here::here("R","utils_keys_filters.R"))
+
 # ───────────────────────────── Config / Paths ─────────────────────────────
 DATA_STAGE <- here("data-stage")
 V6F_PARQ   <- file.path(DATA_STAGE, "susp_v6_features.parquet")  # keys + is_traditional (+ black_q in v6)
@@ -186,12 +188,12 @@ plot_white <- ggplot(
       color = white_q, linetype = series, group = interaction(white_q, series))) +
   geom_line(linewidth = 1.0) +
   geom_point(shape = 21, size = 2.6, stroke = 0.8, fill = "white") +
-  geom_text_repel(aes(label = label_txt),
-                  size = 3, box.padding = 0.25, point.padding = 0.2,
-                  max.overlaps = 30, segment.color = "grey70", segment.size = 0.3) +
-  scale_color_manual(values = quartile_cols,
-                     breaks = c("Q1","Q2","Q3","Q4"),
-                     labels = c("Q1 (Lowest % White)","Q2","Q3","Q4 (Highest % White)")) +
+    geom_text_repel(aes(label = label_txt),
+                    size = 3, box.padding = 0.25, point.padding = 0.2,
+                    max.overlaps = 30, segment.color = "grey70", segment.size = 0.3) +
+    scale_color_manual(values = quartile_cols,
+                       breaks = c("Q1","Q2","Q3","Q4"),
+                       labels = get_quartile_label(1:4, "White")) +
   scale_linetype_manual(values = c("Total (All Students)"="solid",
                                    "Students with Disabilities"="dashed")) +
   scale_y_continuous(labels = percent_format(0.1), limits = y_lim,
@@ -211,12 +213,12 @@ plot_black <- ggplot(
       color = black_q, linetype = series, group = interaction(black_q, series))) +
   geom_line(linewidth = 1.0) +
   geom_point(shape = 21, size = 2.6, stroke = 0.8, fill = "white") +
-  geom_text_repel(aes(label = label_txt),
-                  size = 3, box.padding = 0.25, point.padding = 0.2,
-                  max.overlaps = 30, segment.color = "grey70", segment.size = 0.3) +
-  scale_color_manual(values = quartile_cols,
-                     breaks = c("Q1","Q2","Q3","Q4"),
-                     labels = c("Q1 (Lowest % Black)","Q2","Q3","Q4 (Highest % Black)")) +
+    geom_text_repel(aes(label = label_txt),
+                    size = 3, box.padding = 0.25, point.padding = 0.2,
+                    max.overlaps = 30, segment.color = "grey70", segment.size = 0.3) +
+    scale_color_manual(values = quartile_cols,
+                       breaks = c("Q1","Q2","Q3","Q4"),
+                       labels = get_quartile_label(1:4, "Black")) +
   scale_linetype_manual(values = c("Total (All Students)"="solid",
                                    "Students with Disabilities"="dashed")) +
   scale_y_continuous(labels = percent_format(0.1), limits = y_lim,

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -54,4 +54,14 @@ assert_unique_campus <- function(df, year_col = "year", extra_keys = character()
   df
 }
 
-# assert uniqueness for a district-level frame 
+# construct standardized quartile labels like "Q1 (Lowest % Black)"
+get_quartile_label <- function(q4, race = c("Black", "White")) {
+  race <- match.arg(race)
+  dplyr::case_when(
+    is.na(q4) ~ "Unknown",
+    q4 == 1L ~ paste0("Q1 (Lowest % ", race, ")"),
+    q4 == 2L ~ "Q2",
+    q4 == 3L ~ "Q3",
+    q4 == 4L ~ paste0("Q4 (Highest % ", race, ")")
+  )
+}


### PR DESCRIPTION
## Summary
- centralize quartile label construction via `get_quartile_label`
- use shared quartile labels in feature build script and analyses
- drop duplicate label helpers and sync downstream plots

## Testing
- ❌ `Rscript R/04_feature_black_prop_quartiles.R` *(missing R packages; repository install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c33ee4f9988331968b8a28e0c5efcb