### PR TITLE
Standardize high school label

### DIFF
--- a/Analysis/06_rates_by_race_traditional_vs_other.R
+++ b/Analysis/06_rates_by_race_traditional_vs_other.R
@@ -58,12 +58,12 @@ race_label <- function(code) dplyr::recode(
 )
 
 # --- 4) Derive school group (Traditional vs All other) ------------------------
-# "Traditional" = Elementary/Middle/High (your strict 3-band)
+# "Traditional" = Elementary/Middle/High School (your strict 3-band)
 # "All other"   = Alternative + Other/Unknown (alt/continuation/comm day/juvenile court, atypical/unknown)
 v5 <- v5 %>%
   mutate(
     school_group = dplyr::case_when(
-      level_strict3 %in% c("Elementary","Middle","High") ~ "Traditional",
+      level_strict3 %in% c("Elementary","Middle","High School") ~ "Traditional",
       TRUE                                              ~ "All other"
     )
   )

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -45,7 +45,7 @@ if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 v5 <- v5 %>%
   mutate(
     school_group = dplyr::case_when(
-      level_strict3 %in% c("Elementary","Middle","High") ~ "Traditional",
+      level_strict3 %in% c("Elementary","Middle","High School") ~ "Traditional",
       TRUE                                               ~ "All other"
     )
   )

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -1,5 +1,5 @@
 # analysis/02c_rates_by_level_and_by_level_locale.R
-# One graph per school level (Elementary/Middle/High), and one per (level × locale),
+# One graph per school level (Elementary/Middle/High School), and one per (level × locale),
 # showing all years and all race/ethnicity lines with readable labels.
 
 # --- 1) Setup -----------------------------------------------------------------
@@ -40,7 +40,7 @@ year_levels <- v5 %>%
 if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
 # Levels to include
-LEVELS <- c("Elementary","Middle","High")
+LEVELS <- c("Elementary","Middle","High School")
 
 # --- 4) Race labels & allowed codes ------------------------------------------
 race_label <- function(code) dplyr::recode(

--- a/Analysis/17_tail_by_grade-school_concentration_analysis.R
+++ b/Analysis/17_tail_by_grade-school_concentration_analysis.R
@@ -73,8 +73,8 @@ map_grade_level <- function(x) {
   case_when(
     is.na(x) ~ "Unknown",
     str_detect(x_clean, "elementary|elem|primary|k.*5|k.*6") ~ "Elementary",
-    str_detect(x_clean, "middle|junior|intermediate|6.*8|7.*8") ~ "Middle", 
-    str_detect(x_clean, "high|secondary|9.*12|senior") ~ "High",
+    str_detect(x_clean, "middle|junior|intermediate|6.*8|7.*8") ~ "Middle",
+    str_detect(x_clean, "high|secondary|9.*12|senior") ~ "High School",
     str_detect(x_clean, "k.*12|ungraded|mixed|span") ~ "K-12/Mixed",
     str_detect(x_clean, "adult|continuation") ~ "Adult/Alternative",
     !is.na(x_clean) ~ "Other",
@@ -221,7 +221,7 @@ generate_comparison_tables <- function(df, output_dir) {
   # Compare traditional vs non-traditional by grade level
   comparison_by_grade <- df %>%
     filter(!is.na(level), !is.na(setting), 
-           level %in% c("Elementary", "Middle", "High"),
+           level %in% c("Elementary", "Middle", "High School"),
            setting %in% c("Traditional", "Non-traditional")) %>%
     group_by(year_num, level, setting) %>%
     summarise(

--- a/R/05_feature_school_level.R
+++ b/R/05_feature_school_level.R
@@ -56,7 +56,7 @@ strict3 <- function(gmax) {
   if (is.na(gmax)) return("Other/Unknown")
   if (gmax <= 5) return("Elementary")
   if (gmax <= 8) return("Middle")
-  "High"
+  "High School"
 }
 
 is_alt <- function(school_type) {


### PR DESCRIPTION
## Summary
- Use "High School" for the strict3 grade-band label.
- Align analysis scripts to reference "High School".

## Testing
- `R -q -e "lintr::lint('R/05_feature_school_level.R'); lintr::lint('Analysis/06_rates_by_race_traditional_vs_other.R'); lintr::lint('Analysis/07_rates_trad_vs_other_by_race_by_locale.R'); lintr::lint('Analysis/09_rates_by_level_and_by_level_locale.R'); lintr::lint('Analysis/17_tail_by_grade-school_concentration_analysis.R')"` *(failed: cannot download renv bootstrap)*
- `R --vanilla -q -e "install.packages('lintr', repos='https://cloud.r-project.org')"` *(failed: cannot access repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c33ed2dc008331a93753119023f753