### PR TITLE
feat: centralize suspension reason labels

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -170,20 +170,16 @@ if (has_prop_cols) {
   reason_share_by_year <- v5_race |>
     select(academic_year, total_suspensions, all_of(reason_cols)) |>
     pivot_longer(all_of(reason_cols), names_to = "reason", values_to = "prop") |>
-    mutate(reason_count = prop * total_suspensions) |>
+    mutate(
+      reason = sub("^prop_susp_", "", reason),
+      reason_count = prop * total_suspensions
+    ) |>
     group_by(academic_year, reason) |>
     summarise(total_reason_susp = sum(reason_count, na.rm = TRUE), .groups = "drop") |>
     left_join(ta_susp_by_year, by = "academic_year") |>
+    add_reason_label() |>
     mutate(
       share = if_else(total_susp_all > 0, total_reason_susp / total_susp_all, NA_real_),
-      reason_lab = recode(sub("^prop_susp_", "", reason),
-                          "violent_injury"     = "Violent (Injury)",
-                          "violent_no_injury"  = "Violent (No Injury)",
-                          "weapons_possession" = "Weapons",
-                          "illicit_drug"       = "Illicit Drug",
-                          "defiance_only"      = "Willful Defiance",
-                          "other_reasons"      = "Other",
-                          .default = reason),
       year_fct = factor(academic_year, levels = year_levels)
     )
   

--- a/Analysis/10_eda_hotspots_and_trends.R
+++ b/Analysis/10_eda_hotspots_and_trends.R
@@ -221,14 +221,6 @@ disp_vs_all_rank <- race_rates %>%
 
 # --- Optional: reason-specific rate changes (per student) ---------------------
 reason_cols <- names(base)[grepl("^prop_susp_", names(base))]
-reason_map  <- c(
-  prop_susp_violent_injury     = "Violent (Injury)",
-  prop_susp_violent_no_injury  = "Violent (No Injury)",
-  prop_susp_weapons_possession = "Weapons",
-  prop_susp_illicit_drug       = "Illicit Drug",
-  prop_susp_defiance_only      = "Willful Defiance",
-  prop_susp_other_reasons      = "Other"
-)
 
 val_summary <- NULL
 reason_changes <- NULL
@@ -280,15 +272,18 @@ if (INCLUDE_REASON_ANALYSIS && length(reason_cols)) {
       )
     )
   
-  reason_by_set_year <- reason_long %>%
-    dplyr::group_by(level_strict3, locale_simple, academic_year, year_fct, reason_key) %>%
-    dplyr::summarise(total_reason = sum(reason_count, na.rm = TRUE), .groups = "drop") %>%
-    dplyr::left_join(ta_rates,
-                     by = c("level_strict3","locale_simple","academic_year","year_fct")) %>%
-    dplyr::mutate(
-      reason_rate = safe_rate(total_reason, enroll_TA, MIN_ENROLLMENT_THRESHOLD),
-      reason      = dplyr::recode(reason_key, !!!reason_map)
-    )
+    reason_by_set_year <- reason_long %>%
+      dplyr::group_by(level_strict3, locale_simple, academic_year, year_fct, reason_key) %>%
+      dplyr::summarise(total_reason = sum(reason_count, na.rm = TRUE), .groups = "drop") %>%
+      dplyr::left_join(ta_rates,
+                       by = c("level_strict3","locale_simple","academic_year","year_fct")) %>%
+      dplyr::mutate(
+        reason_rate = safe_rate(total_reason, enroll_TA, MIN_ENROLLMENT_THRESHOLD),
+        reason = sub("^prop_susp_", "", reason_key)
+      ) %>%
+      add_reason_label() %>%
+      dplyr::mutate(reason = reason_lab) %>%
+      dplyr::select(-reason_lab)
   
   reason_changes <- reason_by_set_year %>%
     group_by(level_strict3, locale_simple, reason) %>%

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -5,6 +5,31 @@ suppressPackageStartupMessages({
 
 SPECIAL_SCHOOL_CODES <- c("0000000", "0000001")
 
+# mapping from raw reason keys to display labels
+reason_labels <- dplyr::tibble(
+  reason = c(
+    "violent_injury",
+    "violent_no_injury",
+    "weapons_possession",
+    "illicit_drug",
+    "defiance_only",
+    "other_reasons"
+  ),
+  reason_lab = c(
+    "Violent (Injury)",
+    "Violent (No Injury)",
+    "Weapons",
+    "Illicit Drug",
+    "Willful Defiance",
+    "Other"
+  )
+)
+
+# helper to append readable reason labels
+add_reason_label <- function(df, reason_col = "reason") {
+  dplyr::left_join(df, reason_labels, by = setNames("reason", reason_col))
+}
+
 # build canonical 14-digit CDS keys
 build_keys <- function(df) {
   df %>%


### PR DESCRIPTION
## Summary
- Add `reason_labels` mapping in `utils_keys_filters.R`
- Replace per-script recodes with joins to `reason_labels`
- Standardize reason label handling across analysis scripts

## Testing
- `Rscript Analysis/02_black_rates_by_quartiles.R` *(fails: cannot download packages)*
- `Rscript Analysis/01_trends.R` *(fails: cannot download packages)*
- `Rscript Analysis/10_eda_hotspots_and_trends.R` *(fails: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c33ea6236c8331abdc3dd0960be3ce