### PR TITLE
refactor: centralize locale constants

### DIFF
--- a/Analysis/05a_rates_by_race_by_locale.R
+++ b/Analysis/05a_rates_by_race_by_locale.R
@@ -63,12 +63,9 @@ df_all <- bind_rows(df_total, df_race) %>%
          label_txt=percent(rate, accuracy=0.1))
 
 # Locale sets (two images)
-LOCALES_A <- locale_levels[locale_levels %in% c("City","Suburban")]
-LOCALES_B <- if (INCLUDE_UNKNOWN) {
-  locale_levels[locale_levels %in% c("Rural","Town","Unknown")]
-} else {
-  locale_levels[locale_levels %in% c("Rural","Town")]
-}
+LOCALES_A <- locale_levels[1:2]
+LOCALES_B <- locale_levels[!(locale_levels %in% LOCALES_A)]
+if (!INCLUDE_UNKNOWN) LOCALES_B <- LOCALES_B[LOCALES_B != tail(locale_levels, 1)]
 
 # Race palette (All Students = black)
 race_levels <- df_all %>% distinct(race) %>% arrange(race) %>% pull(race)

--- a/Analysis/05b_rates_by_locale_facet_race_TWO.R
+++ b/Analysis/05b_rates_by_locale_facet_race_TWO.R
@@ -64,7 +64,7 @@ message("Races split into ", length(race_chunks), " image(s).")
 
 # Locale palette and ordering
 loc_levels <- locale_levels
-if (!INCLUDE_UNKNOWN) loc_levels <- setdiff(loc_levels, "Unknown")
+if (!INCLUDE_UNKNOWN) loc_levels <- head(loc_levels, -1)
 pal_locale_use <- pal_locale[loc_levels]
 
 # --- 4) Plot function ---------------------------------------------------------

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -89,7 +89,7 @@ if (!nrow(df_all)) stop("No data available after filtering.")
 
 # Locales to render
 loc_levels <- locale_levels
-if (!INCLUDE_UNKNOWN) loc_levels <- setdiff(loc_levels, "Unknown")
+if (!INCLUDE_UNKNOWN) loc_levels <- head(loc_levels, -1)
 
 # --- 7) Plot function: one locale, race-faceted (≤2 panels) -------------------
 plot_locale_chunk <- function(dat_locale, races, loc_name, i, n_total) {

--- a/Analysis/08_locale_all_years_all_races_one_graph_each.R
+++ b/Analysis/08_locale_all_years_all_races_one_graph_each.R
@@ -58,7 +58,7 @@ df <- v5 %>%
   )
 
 # Locales to render (1 image per)
-loc_levels <- setdiff(locale_levels, "Unknown")
+loc_levels <- head(locale_levels, -1)
 
 # --- 5) Plot helper (Sharpened with Corrected Label Size) ----------------------
 plot_one_locale <- function(loc_name) {

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -91,7 +91,7 @@ if ("All Students" %in% names(pal_race)) pal_race["All Students"] <- "#000000"
 
 # Locales to render
 loc_levels <- locale_levels
-if (!INCLUDE_UNKNOWN_LOCALE) loc_levels <- setdiff(loc_levels, "Unknown")
+if (!INCLUDE_UNKNOWN_LOCALE) loc_levels <- head(loc_levels, -1)
 
 # --- 6) Plot helpers ----------------------------------------------------------
 plot_one_level <- function(level_name) {

--- a/R/02_feature_locale_simple.R
+++ b/R/02_feature_locale_simple.R
@@ -8,6 +8,8 @@ suppressPackageStartupMessages({
   library(stringr)  # string helpers
 })
 
+source(here::here("R", "utils_keys_filters.R"))
+
 message(">>> Running from project root: ", here::here())
 
 # Load v0 from staged data (root-anchored path)
@@ -22,7 +24,8 @@ v1 <- v0 %>%
       !is.na(school_locale) & str_detect(str_to_lower(school_locale), "rural")    ~ "Rural",
       !is.na(school_locale) & str_detect(str_to_lower(school_locale), "town")     ~ "Town",
       TRUE ~ "Unknown"
-    )
+    ),
+    locale_simple = factor(locale_simple, levels = locale_levels)
   )
 
 # Minimal, quiet diagnostics

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -5,7 +5,10 @@ suppressPackageStartupMessages({
 
 SPECIAL_SCHOOL_CODES <- c("0000000", "0000001")
 
-# Consistent locale ordering and color palette used across analyses
+# Canonical set of locale levels used across the project. To add or modify
+# locales, update this vector here rather than creating ad-hoc strings in
+# individual scripts.  The order of `locale_levels` drives plotting and factor
+# levels elsewhere, and `pal_locale` provides a consistent color mapping.
 locale_levels <- c("City", "Suburban", "Town", "Rural", "Unknown")
 pal_locale <- c(
   City     = "#0072B2",


### PR DESCRIPTION
## Summary
- document canonical locale levels and palette
- load canonical locale constants in locale simplification script
- replace ad-hoc locale strings with subsets of canonical levels

## Testing
- `Rscript -e "lintr::lint_dir('R'); lintr::lint_dir('Analysis')"` *(fails: unable to access index for repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c35b515a748331a36d05207d62b6c0