### PR TITLE
Prevent recursive rerun in pipeline script

### DIFF
--- a/run_pipeline.R
+++ b/run_pipeline.R
@@ -43,9 +43,3 @@ for (f in scripts) run(f)
 message("\nAll done: ", format(Sys.time(), usetz = TRUE))
 
 # End of file -----------------------------------------------------------------
-
-
-# --- optional: clear environment and rerun entire pipeline -------------------
-rm(list = ls()); gc()
-source("run_pipeline.R")
-# Rerun the pipeline to ensure everything works from start to finish.


### PR DESCRIPTION
## Summary
- delete environment clearing and self-sourcing block from `run_pipeline.R`
- script now stops after running the main sequence

## Testing
- `apt-get update`
- `apt-get install -y r-base-core` *(partially executed; interrupted due to size)*
- `Rscript run_pipeline.R` *(fails: Rscript not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c37352a00c8331b8f7cd79a8c029b3