### PR TITLE
feat: switch analysis scripts to v6 dataset

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -25,7 +25,7 @@ LABEL_SIZE_REASON  <- 2.8
 NUDGE_X_LABELS     <- 0.15
 
 # ============ Load ============
-v5_raw <- read_parquet(here("data-stage", "susp_v5.parquet")) |> build_keys()
+v5_raw <- read_parquet(here("data-stage", "susp_v6_long.parquet")) |> build_keys()
 
 # Make this robust whether or not aggregate_level exists in v5
 v5 <- {
@@ -38,7 +38,7 @@ v5 <- {
 }
 
 # sanity: TA should be unique per campus-year (the long table itself is not)
-ta_dups <- v5 |> filter(reporting_category == "TA") |>
+ta_dups <- v5 |> filter(category_type == "Race/Ethnicity", subgroup == "All Students") |>
   count(cds_school, academic_year, name = "n") |> filter(n > 1)
 if (nrow(ta_dups) > 0) {
   stop("TA not unique per campus-year in v5. Examples:\n",
@@ -47,18 +47,18 @@ if (nrow(ta_dups) > 0) {
 
 # Year order from TA rows
 year_levels <- v5 |>
-  filter(reporting_category == "TA") |>
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") |>
   distinct(academic_year) |>
   arrange(academic_year) |>
   pull(academic_year)
 
 # ============ Race codes / labels ============
-allowed_codes <- c("RB","RW","RH","RI","RA","RF","RP","RT","RL")  # RL folds into RH
+allowed_codes <- c("Black/African American","White","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races","Hispanic/Latino")  # RL folds into RH
 
 # ============ Plot 1: Suspension RATES (All vs Race) ============
 # Statewide rate = sum(suspensions) / sum(enrollment) from campus-only rows
 overall_rate_by_year <- v5 |>
-  filter(reporting_category == "TA") |>
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") |>
   group_by(academic_year) |>
   summarise(
     susp   = sum(total_suspensions, na.rm = TRUE),
@@ -72,8 +72,8 @@ overall_rate_by_year <- v5 |>
   )
 
 race_rate_by_year <- v5 |>
-  filter(reporting_category %in% allowed_codes) |>
-  mutate(race = race_label(reporting_category)) |>
+  filter(subgroup %in% allowed_codes) |>
+  mutate(race = canon_race_label(subgroup)) |>
   filter(!is.na(race)) |>
   group_by(academic_year, race) |>
   summarise(
@@ -147,11 +147,11 @@ p_rate_totals <- ggplot() +
 has_prop_cols <- any(grepl("^prop_susp_", names(v5)))
 if (has_prop_cols) {
   ta_susp_by_year <- v5 |>
-    filter(reporting_category == "TA") |>
+    filter(category_type == "Race/Ethnicity", subgroup == "All Students") |>
     group_by(academic_year) |>
     summarise(total_susp_all = sum(total_suspensions, na.rm = TRUE), .groups = "drop")
   
-  v5_race <- v5 |> filter(reporting_category != "TA")
+  v5_race <- v5 |> filter(subgroup != "All Students")
   reason_cols <- names(v5_race)[grepl("^prop_susp_", names(v5_race))]
   
   reason_share_by_year <- v5_race |>

--- a/Analysis/02b_black_rates_by_quartiles.R
+++ b/Analysis/02b_black_rates_by_quartiles.R
@@ -20,12 +20,12 @@ suppressPackageStartupMessages({
 source(here::here("R","utils_keys_filters.R"))
 
 # ------------ load & guards -------------------
-v5 <- read_parquet(here("data-stage","susp_v5.parquet")) %>%
+v5 <- read_parquet(here("data-stage","susp_v6_long.parquet")) %>%
   build_keys() %>%
   filter_campus_only()   # drops 0000000/0000001 and non-school rows
 
 need_cols <- c(
-  "reporting_category","academic_year",
+  "subgroup","academic_year",
   "total_suspensions","cumulative_enrollment",
   "black_prop_q4","black_prop_q_label","white_prop_q4","white_prop_q_label"
 )
@@ -38,7 +38,7 @@ if (!"white_prop_q_label" %in% names(v5))  v5 <- v5 %>% mutate(white_prop_q_labe
 
 # year order (from TA rows with positive enrollment)
 year_levels <- v5 %>%
-  filter(reporting_category == "TA", cumulative_enrollment > 0) %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students", cumulative_enrollment > 0) %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 # reason columns (skip reason plots gracefully if none found)
@@ -52,7 +52,7 @@ if (length(reason_cols) == 0) {
 agg_rb_rates_and_counts <- function(v5, quart_var) {
   # total RB rate & counts
   totals <- v5 %>%
-    filter(reporting_category == "RB", !is.na(.data[[quart_var]]), .data[[quart_var]] != "Unknown") %>%
+    filter(subgroup == "Black/African American", !is.na(.data[[quart_var]]), .data[[quart_var]] != "Unknown") %>%
     group_by(academic_year, .data[[quart_var]]) %>%
     summarise(
       susp   = sum(total_suspensions, na.rm = TRUE),
@@ -67,7 +67,7 @@ agg_rb_rates_and_counts <- function(v5, quart_var) {
   
   # reason-specific RB rate
     reasons_rate <- v5 %>%
-      filter(reporting_category == "RB", !is.na(.data[[quart_var]])) %>%
+      filter(subgroup == "Black/African American", !is.na(.data[[quart_var]])) %>%
       select(academic_year, .data[[quart_var]], cumulative_enrollment, total_suspensions, all_of(reason_cols)) %>%
       pivot_longer(all_of(reason_cols), names_to = "reason", values_to = "prop") %>%
       mutate(
@@ -93,7 +93,7 @@ agg_rb_rates_and_counts <- function(v5, quart_var) {
 # shares: within year × quartile, fraction of RB suspensions by reason
 agg_rb_reason_shares <- function(v5, quart_var) {
     rb_reason_share <- v5 %>%
-      filter(reporting_category == "RB", !is.na(.data[[quart_var]])) %>%
+      filter(subgroup == "Black/African American", !is.na(.data[[quart_var]])) %>%
       select(academic_year, .data[[quart_var]], total_suspensions, all_of(reason_cols)) %>%
       pivot_longer(all_of(reason_cols), names_to = "reason", values_to = "prop") %>%
       mutate(

--- a/Analysis/02c_claude_black_rates_by_quartiles.R
+++ b/Analysis/02c_claude_black_rates_by_quartiles.R
@@ -24,11 +24,11 @@ white_quartile_colors <- setNames(
 
 # --- 2) Load + guards ---------------------------------------------------------
 message("Loading data...")
-v5 <- arrow::read_parquet(here::here("data-stage","susp_v5.parquet")) %>%
+v5 <- arrow::read_parquet(here::here("data-stage","susp_v6_long.parquet")) %>%
   build_keys() %>%            # adds cds_district, cds_school (canonical keys)
   filter_campus_only()        # drops fake schools + special codes
 
-need_cols <- c("reporting_category","academic_year",
+need_cols <- c("subgroup","academic_year",
                "total_suspensions","cumulative_enrollment",
                "black_prop_q4","white_prop_q4")
 missing <- setdiff(need_cols, names(v5))
@@ -40,11 +40,11 @@ if (!"white_prop_q_label" %in% names(v5)) v5 <- v5 %>% mutate(white_prop_q_label
 
 # order x-axis by TA years that actually have enrollment
 year_levels <- v5 %>%
-  filter(reporting_category == "TA", cumulative_enrollment > 0) %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students", cumulative_enrollment > 0) %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 # restrict to Black rows for all calculations
-black_students_data <- v5 %>% filter(reporting_category == "RB")
+black_students_data <- v5 %>% filter(subgroup == "Black/African American")
 
 # Reason columns: prefer *_count columns if present; otherwise derive from proportions
 has_count_cols <- all(c(

--- a/Analysis/05a_rates_by_race_by_locale.R
+++ b/Analysis/05a_rates_by_race_by_locale.R
@@ -27,22 +27,22 @@ set.seed(42)
 
 # --- 3) Load & prepare --------------------------------------------------------
 message("Loading data…")
-v5_path <- here::here("data-stage","susp_v5.parquet")
+v5_path <- here::here("data-stage","susp_v6_long.parquet")
 if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
 v5 <- arrow::read_parquet(v5_path)
 
-need <- c("reporting_category","academic_year","locale_simple",
+need <- c("subgroup","academic_year","locale_simple",
           "total_suspensions","cumulative_enrollment")
 miss <- setdiff(need, names(v5))
 if (length(miss)) stop("Missing columns: ", paste(miss, collapse=", "))
 
 year_levels <- v5 %>%
-  filter(reporting_category == "TA") %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 # All Students
 df_total <- v5 %>%
-  filter(reporting_category=="TA") %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   group_by(academic_year, locale_simple) %>%
   summarise(susp=sum(total_suspensions, na.rm=TRUE),
             enroll=sum(cumulative_enrollment, na.rm=TRUE), .groups="drop") %>%
@@ -50,8 +50,8 @@ df_total <- v5 %>%
 
 # Race-specific
 df_race <- v5 %>%
-  filter(reporting_category %in% c("RB","RW","RH","RL","RI","RA","RF","RP","RT")) %>%
-  mutate(race=race_label(reporting_category)) %>%
+  filter(subgroup %in% c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")) %>%
+  mutate(race=canon_race_label(subgroup)) %>%
   filter(!is.na(race)) %>%
   group_by(academic_year, locale_simple, race) %>%
   summarise(susp=sum(total_suspensions, na.rm=TRUE),

--- a/Analysis/05b_rates_by_locale_facet_race_TWO.R
+++ b/Analysis/05b_rates_by_locale_facet_race_TWO.R
@@ -27,21 +27,21 @@ set.seed(42)
 
 # --- 3) Load & prepare --------------------------------------------------------
 message("Loading and preparing data…")
-v5_path <- here::here("data-stage","susp_v5.parquet")
+v5_path <- here::here("data-stage","susp_v6_long.parquet")
 if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
 v5 <- arrow::read_parquet(v5_path)
 
-need <- c("reporting_category","academic_year","locale_simple",
+need <- c("subgroup","academic_year","locale_simple",
           "total_suspensions","cumulative_enrollment")
 miss <- setdiff(need, names(v5))
 if (length(miss)) stop("Missing required columns: ", paste(miss, collapse=", "))
 
 year_levels <- v5 %>%
-  filter(reporting_category == "TA") %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 df_all <- v5 %>%
-  mutate(race = race_label(reporting_category)) %>%
+  mutate(race = canon_race_label(subgroup)) %>%
   filter(!is.na(race)) %>%
   group_by(academic_year, locale_simple, race) %>%
   summarise(susp=sum(total_suspensions, na.rm=TRUE),

--- a/Analysis/06_rates_by_race_traditional_vs_other.R
+++ b/Analysis/06_rates_by_race_traditional_vs_other.R
@@ -33,22 +33,22 @@ set.seed(42)
 
 # --- 3) Load & guards ---------------------------------------------------------
 message("Loading v5…")
-v5_path <- here::here("data-stage","susp_v5.parquet")
+v5_path <- here::here("data-stage","susp_v6_long.parquet")
 if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
 v5 <- arrow::read_parquet(v5_path)
 
-need <- c("reporting_category","academic_year","school_level",
+need <- c("subgroup","academic_year","school_level",
           "school_type","total_suspensions","cumulative_enrollment")
 miss <- setdiff(need, names(v5))
 if (length(miss)) stop("Missing columns in v5: ", paste(miss, collapse=", "))
 
 # academic year order
 year_levels <- v5 %>%
-  filter(reporting_category == "TA") %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 if (!length(year_levels)) stop("No TA rows to establish year order.")
 
-# Race label map (RD omitted; RL -> RH) handled by race_label() helper
+# Race label map (RD omitted; RL -> RH) handled by canon_race_label() helper
 
 # --- 4) Derive school group (Traditional vs All other) ------------------------
 # "Traditional" = Elementary/Middle/High (your strict 3-band)
@@ -79,7 +79,7 @@ all_other_note <- paste0(
 # --- 5) Build pooled rates by year × school_group × race ----------------------
 # All Students baseline
 df_total <- v5 %>%
-  filter(reporting_category == "TA") %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   group_by(academic_year, school_group) %>%
   summarise(
     susp   = sum(total_suspensions, na.rm = TRUE),
@@ -90,10 +90,10 @@ df_total <- v5 %>%
          race = "All Students")
 
 # Race-specific
-allowed_race_codes <- c("RB","RW","RH","RL","RI","RA","RF","RP","RT")
+allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")
 df_race <- v5 %>%
-  filter(reporting_category %in% allowed_race_codes) %>%
-  mutate(race = race_label(reporting_category)) %>%
+  filter(canon_race_label(subgroup) %in% allowed_races) %>%
+  mutate(race = canon_race_label(subgroup)) %>%
   filter(!is.na(race)) %>%
   group_by(academic_year, school_group, race) %>%
   summarise(

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -29,17 +29,17 @@ set.seed(42)
 
 # --- 3) Load & guards ---------------------------------------------------------
 message("Loading data…")
-v5_path <- here::here("data-stage","susp_v5.parquet")
+v5_path <- here::here("data-stage","susp_v6_long.parquet")
 if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
 v5 <- arrow::read_parquet(v5_path)
 
-need <- c("reporting_category","academic_year","locale_simple","school_level",
+need <- c("subgroup","academic_year","locale_simple","school_level",
           "school_type","total_suspensions","cumulative_enrollment")
 miss <- setdiff(need, names(v5))
 if (length(miss)) stop("Missing required columns: ", paste(miss, collapse=", "))
 
 year_levels <- v5 %>%
-  dplyr::filter(reporting_category == "TA") %>%
+  dplyr::filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   dplyr::distinct(academic_year) %>% dplyr::arrange(academic_year) %>% dplyr::pull(academic_year)
 if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
@@ -63,14 +63,14 @@ all_other_note <- paste0("All other = Alternative (e.g., ", alt_found_pretty,
                          ") + schools with Other/Unknown grade spans.")
 
 # --- 5) Race labels -----------------------------------------------------------
-# handled via shared race_label() helper
+# handled via shared canon_race_label() helper
 
 # --- 6) Aggregate to pooled rates by year × locale × race × group ------------
-allowed_race_codes <- c("RB","RW","RH","RL","RI","RA","RF","RP","RT","TA")
+allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races","All Students")
 
 df_all <- v5 %>%
-  mutate(race = race_label(reporting_category)) %>%
-  filter(!is.na(race), reporting_category %in% allowed_race_codes) %>%
+  mutate(race = canon_race_label(subgroup)) %>%
+  filter(!is.na(race), canon_race_label(subgroup) %in% allowed_races) %>%
   group_by(academic_year, locale_simple, school_group, race) %>%
   summarise(
     susp   = sum(total_suspensions, na.rm = TRUE),

--- a/Analysis/08_locale_all_years_all_races_one_graph_each.R
+++ b/Analysis/08_locale_all_years_all_races_one_graph_each.R
@@ -21,29 +21,29 @@ IMG_DPI           <- 300
 set.seed(42)
 
 # --- 3) Load & guards ---------------------------------------------------------
-v5_path <- here::here("data-stage","susp_v5.parquet")
+v5_path <- here::here("data-stage","susp_v6_long.parquet")
 if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
 v5 <- arrow::read_parquet(v5_path)
 
-need <- c("reporting_category","academic_year","locale_simple",
+need <- c("subgroup","academic_year","locale_simple",
           "total_suspensions","cumulative_enrollment")
 miss <- setdiff(need, names(v5))
 if (length(miss)) stop("Missing columns: ", paste(miss, collapse=", "))
 
 # Year order driven by TA
 year_levels <- v5 %>%
-  filter(reporting_category == "TA") %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
 # --- 4) Race labels and Data Prep ---------------------------------------------
 # Keep TA + known races; drop RD (Not Reported)
-allowed_codes <- c("TA","RB","RW","RH","RL","RI","RA","RF","RP","RT")
+allowed_codes <- c("All Students","Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")
 
 df <- v5 %>%
-  filter(reporting_category %in% allowed_codes) %>%
+  filter(subgroup %in% allowed_codes) %>%
   mutate(
-    race = race_label(reporting_category),
+    race = canon_race_label(subgroup),
     year_fct = factor(academic_year, levels = year_levels)
   ) %>%
   group_by(locale_simple, race, academic_year, year_fct) %>%

--- a/Analysis/10_analysis_by_size_and_race.R
+++ b/Analysis/10_analysis_by_size_and_race.R
@@ -13,15 +13,15 @@ suppressPackageStartupMessages({
 
 # --- 2) Load Data -------------------------------------------------------------
 message("Loading data...")
-v5 <- arrow::read_parquet(here::here("data-stage", "susp_v5.parquet"))
+v5 <- arrow::read_parquet(here::here("data-stage", "susp_v6_long.parquet"))
 
 # --- 3) Prepare Data for Plotting ---------------------------------------------
 message("Preparing data for analysis...")
 
 rates_by_size_race <- v5 %>%
   filter(enroll_q_label != "Unknown", !is.na(enroll_q_label)) %>%
-  filter(reporting_category != "TA") %>%
-  group_by(academic_year, enroll_q_label, reporting_category) %>%
+  filter(subgroup != "All Students") %>%
+  group_by(academic_year, enroll_q_label, subgroup) %>%
   summarise(
     total_suspensions = sum(total_suspensions, na.rm = TRUE),
     cumulative_enrollment = sum(cumulative_enrollment, na.rm = TRUE),
@@ -32,16 +32,16 @@ rates_by_size_race <- v5 %>%
   ) %>%
   mutate(
     student_group = case_when(
-      reporting_category == "RB" ~ "Black",
-      reporting_category == "RI" ~ "American Indian",
-      reporting_category == "RA" ~ "Asian",
-      reporting_category == "RF" ~ "Filipino",
-      reporting_category == "RH" ~ "Hispanic",
-      reporting_category == "RP" ~ "Pacific Islander",
-      reporting_category == "RW" ~ "White",
-      reporting_category == "RT" ~ "Two or More Races",
-      reporting_category == "RD" ~ "Not Reported",
-      TRUE ~ reporting_category
+      subgroup == "Black/African American" ~ "Black",
+      subgroup == "American Indian/Alaska Native" ~ "American Indian",
+      subgroup == "Asian" ~ "Asian",
+      subgroup == "Filipino" ~ "Filipino",
+      subgroup == "Hispanic/Latino" ~ "Hispanic",
+      subgroup == "Pacific Islander" ~ "Pacific Islander",
+      subgroup == "White" ~ "White",
+      subgroup == "Two or More Races" ~ "Two or More Races",
+      subgroup == "RD" ~ "Not Reported",
+      TRUE ~ subgroup
     )
   )
 

--- a/Analysis/10_eda_hotspots_and_trends.R
+++ b/Analysis/10_eda_hotspots_and_trends.R
@@ -38,18 +38,18 @@ trend_dir_spearman <- function(v) {
 }
 
 # --- Load & guards -----------------------------------------------------------
-v5_path <- here("data-stage", "susp_v5.parquet")
+v5_path <- here("data-stage", "susp_v6_long.parquet")
 if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
 v5 <- read_parquet(v5_path)
 
-required_cols <- c("reporting_category","academic_year","total_suspensions",
+required_cols <- c("subgroup","academic_year","total_suspensions",
                    "cumulative_enrollment","school_level","locale_simple")
 missing_cols <- setdiff(required_cols, names(v5))
 if (length(missing_cols)) stop("Missing required columns: ", paste(missing_cols, collapse = ", "))
 
 # Order academic years (driven by TA)
 year_levels <- v5 %>%
-  filter(reporting_category == "TA") %>%
+  filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull()
 if (!length(year_levels)) stop("No TA rows found to anchor academic_year order.")
 
@@ -61,7 +61,7 @@ if (isTRUE(DROP_UNKNOWN_LOCALE)) {
 # --- Base with labels & factors ---------------------------------------------
 base <- v5 %>%
   mutate(
-    race     = race_label(reporting_category),
+    race     = canon_race_label(subgroup),
     year_fct = factor(academic_year, levels = year_levels, ordered = TRUE)
   ) %>%
   filter(!is.na(race)) %>%

--- a/Analysis/15_merge_demographic_categories.R
+++ b/Analysis/15_merge_demographic_categories.R
@@ -2,7 +2,7 @@
 # Merge additional demographic categories with race data for intersectional EDA
 # analysis/15_merge_demographic_categories.R
 # Purpose: Merge additional demographic categories with race data for intersectional EDA
-# Inputs:  - data-stage/susp_v5.parquet (race/ethnicity suspension data)
+# Inputs:  - data-stage/susp_v6_long.parquet (race/ethnicity suspension data)
 #          - data-stage/oth_long.parquet (other demographic categories)
 # Outputs: - 15_demographic_*.xlsx (disparity analysis)
 #          - 15_demographic_flags.csv (merge-ready summary)
@@ -24,7 +24,7 @@ suppressPackageStartupMessages({
 source(here("R", "utils_keys_filters.R"))
 
 # -------- Config -------------------------------------------------------------
-RACE_DATA_PATH <- here("data-stage", "susp_v5.parquet")
+RACE_DATA_PATH <- here("data-stage", "susp_v6_long.parquet")
 OTH_PARQUET    <- here("data-stage", "oth_long.parquet")
 MIN_ENROLLMENT_THRESHOLD <- 10
 
@@ -182,7 +182,7 @@ cat("Capped", sum(demo_data$rate_flag, na.rm = TRUE), "impossible suspension cou
 # -------- Create canonical school attributes --------------------------------
 # Year ordering (prefer TA in race_data if present)
 year_levels <- race_data %>%
-  filter(if ("reporting_category" %in% names(.)) reporting_category == "TA" else TRUE) %>%
+  filter(if ("subgroup" %in% names(.)) category_type == "Race/Ethnicity", subgroup == "All Students" else TRUE) %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull()
 
 if (!length(year_levels)) {

--- a/Analysis/16_tail_concentration_analysis.R
+++ b/Analysis/16_tail_concentration_analysis.R
@@ -26,7 +26,7 @@ suppressPackageStartupMessages({
 
 # Data paths - updated for your repository structure
 DATA_STAGE <- here("data-stage")
-INPUT_PATH <- file.path(DATA_STAGE, "susp_v5.parquet")  # Main suspension data
+INPUT_PATH <- file.path(DATA_STAGE, "susp_v6_long.parquet")  # Main suspension data
 V6F_PARQ   <- file.path(DATA_STAGE, "susp_v6_features.parquet")  # School features
 
 # Output directory
@@ -164,7 +164,7 @@ if (length(missing_cols) > 0) {
 # Process and clean data
 dat <- dat0 %>%
   # Filter to Total/All Students records only
-  filter(str_to_lower(reporting_category) %in% c("total", "all students", "ta")) %>%
+  filter(str_to_lower(subgroup) %in% c("total", "all students", "ta")) %>%
   rename(
     school_id   = !!sym(cols$school_id),
     year        = !!sym(cols$year),

--- a/Analysis/17_tail_by_grade-school_concentration_analysis.R
+++ b/Analysis/17_tail_by_grade-school_concentration_analysis.R
@@ -17,7 +17,7 @@ suppressPackageStartupMessages({
 
 # Data paths - updated for your repository structure
 DATA_STAGE <- here("data-stage")
-INPUT_PATH <- file.path(DATA_STAGE, "susp_v5.parquet")  # Main suspension data
+INPUT_PATH <- file.path(DATA_STAGE, "susp_v6_long.parquet")  # Main suspension data
 V6F_PARQ   <- file.path(DATA_STAGE, "susp_v6_features.parquet")  # School features
 
 # Output directory
@@ -285,7 +285,7 @@ if (length(missing_cols) > 0) {
 # Process and clean data
 dat <- dat0 %>%
   # Filter to Total/All Students records only
-  filter(str_to_lower(reporting_category) %in% c("total", "all students", "ta")) %>%
+  filter(str_to_lower(subgroup) %in% c("total", "all students", "ta")) %>%
   rename(
     school_id   = !!sym(cols$school_id),
     year        = !!sym(cols$year),

--- a/Analysis/17_tail_concentration_by_level.R
+++ b/Analysis/17_tail_concentration_by_level.R
@@ -89,7 +89,7 @@ pareto_shares <- function(df, top_ps = TOP_PCT) {
 raw <- read_parquet(INPUT_PATH) %>% clean_names()
 
 susp <- raw %>%
-  filter(str_to_lower(reporting_category) %in% c("total", "all students", "ta")) %>%
+  filter(str_to_lower(subgroup) %in% c("total", "all students", "ta")) %>%
   transmute(
     school_id   = school_code,
     year        = academic_year,

--- a/Analysis/18_comprehensive_suspension_rates_analysis.R
+++ b/Analysis/18_comprehensive_suspension_rates_analysis.R
@@ -18,7 +18,7 @@ message(">>> Running from project root: ", here::here())
 
 # Data paths
 DATA_STAGE <- here("data-stage")
-V5_PARQ <- file.path(DATA_STAGE, "susp_v5.parquet")
+V5_PARQ <- file.path(DATA_STAGE, "susp_v6_long.parquet")
 V6F_PARQ <- file.path(DATA_STAGE, "susp_v6_features.parquet")
 
 # Output setup
@@ -106,7 +106,7 @@ v5_complete <- v5 %>%
   transmute(
     school_code = school_code,
     year = as.character(academic_year),
-    race_ethnicity = canon_race_label(reporting_category),
+    race_ethnicity = canon_race_label(subgroup),
     enrollment = as.numeric(cumulative_enrollment),
     total_suspensions = as.numeric(total_suspensions),
     undup_suspensions = as.numeric(unduplicated_count_of_students_suspended_total),

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -96,16 +96,39 @@ assert_unique_campus <- function(df, year_col = "year", extra_keys = character()
 # assert uniqueness for a district-level frame
 # (function intentionally left for future implementation)
 
-# map CRDC race codes to descriptive labels
-race_label <- function(code) dplyr::recode(
-  code,
-  RB = "Black/African American", RW = "White",
-  RH = "Hispanic/Latino", RL = "Hispanic/Latino",
-  RI = "American Indian/Alaska Native", RA = "Asian",
-  RF = "Filipino", RP = "Pacific Islander",
-  RT = "Two or More Races", TA = "All Students",
-  .default = NA_character_
-)
+# Map various race/ethnicity inputs to canonical labels. Accepts either
+# legacy reporting-category codes (e.g., "RB") or descriptive subgroup
+# names (e.g., "Black").
+canon_race_label <- function(x) {
+  x_clean <- stringr::str_to_lower(stringr::str_trim(x))
+  dplyr::case_when(
+    x_clean %in% c("ta", "total", "all students", "all_students") ~ "All Students",
+    x_clean %in% c("ra", "asian") ~ "Asian",
+    x_clean %in% c(
+      "rb", "black", "african american", "black/african american",
+      "african_american"
+    ) ~ "Black/African American",
+    x_clean %in% c("rf", "filipino") ~ "Filipino",
+    x_clean %in% c(
+      "rh", "rl", "hispanic", "latino", "hispanic/latino",
+      "hispanic_latino"
+    ) ~ "Hispanic/Latino",
+    x_clean %in% c(
+      "ri", "american indian", "alaska native",
+      "american indian/alaska native", "native american"
+    ) ~ "American Indian/Alaska Native",
+    x_clean %in% c("rp", "pacific islander", "native hawaiian") ~ "Pacific Islander",
+    x_clean %in% c(
+      "rt", "two or more", "two or more races", "multirace",
+      "multiple"
+    ) ~ "Two or More Races",
+    x_clean %in% c("rw", "white") ~ "White",
+    TRUE ~ NA_character_
+  )
+}
+
+# Backward-compatible alias used by legacy scripts
+race_label <- canon_race_label
 
 =======
 # construct standardized quartile labels like "Q1 (Lowest % Black)"


### PR DESCRIPTION
## Summary
- migrate Analysis scripts from `susp_v5.parquet` to `susp_v6_long.parquet`
- rely on `canon_race_label` helper and `category_type`/`subgroup` fields instead of reporting codes
- provide canonical race labeling utility in `utils_keys_filters.R`

## Testing
- `R -q -e 'sessionInfo()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3735e492483318e4f6fa3ee29ead6