### PR TITLE
feat: search v6 race long files

### DIFF
--- a/Analysis/15a_emit_nonintersectional_exports.R
+++ b/Analysis/15a_emit_nonintersectional_exports.R
@@ -79,12 +79,12 @@ canonicalize_undup <- function(df) {
 # 1) Read race-long (has reason columns)
 # -------------------------------------------------------------------
 RACE_LONG_CANDIDATES <- c(
-  here("data-stage", "susp_v5_long_strict.parquet"),
-  here("data-stage", "susp_v5_long.parquet")
+  here("data-stage", "susp_v6_long_strict.parquet"),
+  here("data-stage", "susp_v6_long.parquet")
 )
 RACE_LONG_PATH <- RACE_LONG_CANDIDATES[which(file.exists(RACE_LONG_CANDIDATES))][1]
 if (is.na(RACE_LONG_PATH)) {
-  stop("[15a] Needed long race file missing. Expected one of:\n  - data-stage/susp_v5_long_strict.parquet\n  - data-stage/susp_v5_long.parquet")
+  stop("[15a] Needed long race file missing. Expected one of:\n  - data-stage/susp_v6_long_strict.parquet\n  - data-stage/susp_v6_long.parquet")
 }
 
 race_long <- arrow::read_parquet(RACE_LONG_PATH) %>%


### PR DESCRIPTION
## Summary
- prefer v6 race-long parquet files for non-intersectional exports

## Testing
- `Rscript --vanilla Analysis/15a_emit_nonintersectional_exports.R` *(fails: there is no package called 'arrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c384a4b0188331bf607f3e012b3fdb