### PR TITLE
Use relative path for OTH demographics data

### DIFF
--- a/R/01b_ingest_demographics.R
+++ b/R/01b_ingest_demographics.R
@@ -12,11 +12,11 @@ suppressPackageStartupMessages({
 })
 
 # -------- Config -------------------------------------------------------------
-# Option A: absolute path (works today)
-DEMO_DATA_PATH <- "/Users/michaelcorral/Library/CloudStorage/GoogleDrive-mdcorral@g.ucla.edu/.shortcut-targets-by-id/1qNAOKIg0UjuT3XWFlk4dkDLN6UPWJVGx/Center for the Transformation of Schools/Research/CA Race Education And Community Healing (REACH)/2. REACH Network (INTERNAL)/15. REACH Baseline Report_Summer 2025/6. R Data Analysis Project Folders/reach-suspensions/data-raw/copy_CDE_suspensions_1718-2324_sc_oth.xlsx"
-
-# Option B: if you ever move the XLSX into your repo:
-# DEMO_DATA_PATH <- here("data-raw", "copy_CDE_suspensions_1718-2324_sc_oth.xlsx")
+# Path to the OTH demographic XLSX. Can be overridden by OTH_RAW_PATH env var.
+DEMO_DATA_PATH <- Sys.getenv("OTH_RAW_PATH")
+if (!nzchar(DEMO_DATA_PATH)) {
+  DEMO_DATA_PATH <- here("data-raw", "copy_CDE_suspensions_1718-2324_sc_oth.xlsx")
+}
 
 OUT_PARQUET <- here("data-stage", "oth_long.parquet")
 MIN_ENROLLMENT_THRESHOLD <- 10


### PR DESCRIPTION
## Summary
- Replace absolute DEMO_DATA_PATH with a repo-relative `here()` path
- Allow `OTH_RAW_PATH` environment variable to override default

## Testing
- `Rscript R/01b_ingest_demographics.R` *(fails: cannot download renv packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c3847a62b48331a16d27d5d9c3ffc3