### PR TITLE
Centralize suspension reason labels

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -170,13 +170,9 @@ if (has_prop_cols) {
       year_fct = factor(academic_year, levels = year_levels)
     )
   
-  reason_colors <- c(
-    "Willful Defiance"   = "#d62728",
-    "Violent (Injury)"   = "#ff7f0e",
-    "Violent (No Injury)"= "#2ca02c",
-    "Weapons"            = "#1f77b4",
-    "Illicit Drug"       = "#9467bd",
-    "Other"              = "#8c564b"
+  reason_colors <- setNames(
+    c("#d62728", "#ff7f0e", "#2ca02c", "#1f77b4", "#9467bd", "#8c564b"),
+    reason_labels$reason_lab
   )
   
   reason_labels_all <- reason_share_by_year |> filter(!is.na(share))

--- a/R/06_feature_reason_shares.R
+++ b/R/06_feature_reason_shares.R
@@ -49,7 +49,9 @@ v5_long <- v5 %>%
     starts_with("prop_susp_"),
     names_to  = "reason",
     values_to = "prop_of_total_susp"
-  )
+  ) %>%
+  mutate(reason = sub("^prop_susp_", "", reason)) %>%
+  add_reason_label()
 
 # ---- write outputs ---------------------------------------------------------
 arrow::write_parquet(v5,      here::here("data-stage", "susp_v5.parquet"))

--- a/R/08_analysis_black_student_rates.R
+++ b/R/08_analysis_black_student_rates.R
@@ -60,22 +60,32 @@ p1_black_by_black <- ggplot(rate_by_black_quartile, aes(x = academic_year, y = s
 reason_rate_by_black_quartile <- black_students_data %>%
   # Most robust filter
   filter(
-    reporting_category == "RB", 
-    !is.na(black_prop_q_label), 
+    reporting_category == "RB",
+    !is.na(black_prop_q_label),
     black_prop_q_label != "Unknown"
   ) %>%
   group_by(academic_year, black_prop_q_label) %>%
   summarise(
-    Defiance = sum(suspension_count_defiance_only, na.rm = TRUE),
-    `Violent Injury` = sum(suspension_count_violent_incident_injury, na.rm = TRUE),
-    `Violent No Injury` = sum(suspension_count_violent_incident_no_injury, na.rm = TRUE),
-    Weapons = sum(suspension_count_weapons_possession, na.rm = TRUE),
-    Drugs = sum(suspension_count_illicit_drug_related, na.rm = TRUE),
-    Other = sum(suspension_count_other_reasons, na.rm = TRUE),
+    across(
+      c(
+        violent_injury     = suspension_count_violent_incident_injury,
+        violent_no_injury  = suspension_count_violent_incident_no_injury,
+        weapons_possession = suspension_count_weapons_possession,
+        illicit_drug       = suspension_count_illicit_drug_related,
+        defiance_only      = suspension_count_defiance_only,
+        other_reasons      = suspension_count_other_reasons
+      ),
+      ~ sum(.x, na.rm = TRUE)
+    ),
     enrollment = sum(cumulative_enrollment, na.rm = TRUE),
     .groups = "drop"
   ) %>%
-  pivot_longer(cols = -c(academic_year, black_prop_q_label, enrollment), names_to = "suspension_reason", values_to = "count") %>%
+  pivot_longer(
+    cols = -c(academic_year, black_prop_q_label, enrollment),
+    names_to = "reason",
+    values_to = "count"
+  ) %>%
+  add_reason_label() %>%
   mutate(reason_rate = if_else(enrollment > 0, (count / enrollment), 0))
 
 # Data for total labels in each facet
@@ -85,7 +95,7 @@ labels_reason_black_q <- reason_rate_by_black_quartile %>%
 
 # --- 7) CHART 1B: Suspension Reason Rates by Black Enrollment Quartile ------
 p2_reasons_by_black <- ggplot(reason_rate_by_black_quartile, aes(x = academic_year, y = reason_rate,
-                                                                 group = suspension_reason, fill = suspension_reason)) +
+                                                                 group = reason_lab, fill = reason_lab)) +
   geom_area(position = "stack") +
   geom_text(data = labels_reason_black_q,
             aes(x = academic_year, y = total_rate, label = percent(total_rate, accuracy = 0.1)),
@@ -136,16 +146,26 @@ reason_rate_by_white_quartile <- black_students_data %>%
   filter(white_prop_q_label != "Unknown") %>%
   group_by(academic_year, white_prop_q_label) %>%
   summarise(
-    Defiance = sum(suspension_count_defiance_only, na.rm = TRUE),
-    `Violent Injury` = sum(suspension_count_violent_incident_injury, na.rm = TRUE),
-    `Violent No Injury` = sum(suspension_count_violent_incident_no_injury, na.rm = TRUE),
-    Weapons = sum(suspension_count_weapons_possession, na.rm = TRUE),
-    Drugs = sum(suspension_count_illicit_drug_related, na.rm = TRUE),
-    Other = sum(suspension_count_other_reasons, na.rm = TRUE),
+    across(
+      c(
+        violent_injury     = suspension_count_violent_incident_injury,
+        violent_no_injury  = suspension_count_violent_incident_no_injury,
+        weapons_possession = suspension_count_weapons_possession,
+        illicit_drug       = suspension_count_illicit_drug_related,
+        defiance_only      = suspension_count_defiance_only,
+        other_reasons      = suspension_count_other_reasons
+      ),
+      ~ sum(.x, na.rm = TRUE)
+    ),
     enrollment = sum(cumulative_enrollment, na.rm = TRUE),
     .groups = "drop"
   ) %>%
-  pivot_longer(cols = -c(academic_year, white_prop_q_label, enrollment), names_to = "suspension_reason", values_to = "count") %>%
+  pivot_longer(
+    cols = -c(academic_year, white_prop_q_label, enrollment),
+    names_to = "reason",
+    values_to = "count"
+  ) %>%
+  add_reason_label() %>%
   mutate(reason_rate = if_else(enrollment > 0, (count / enrollment), 0))
 
 # Data for total labels in each facet
@@ -155,7 +175,7 @@ labels_reason_white_q <- reason_rate_by_white_quartile %>%
 
 # --- 11) CHART 2B: Suspension Reason Rates by White Enrollment Quartile ------
 p4_reasons_by_white <- ggplot(reason_rate_by_white_quartile, aes(x = academic_year, y = reason_rate,
-                                                                 group = suspension_reason, fill = suspension_reason)) +
+                                                                 group = reason_lab, fill = reason_lab)) +
   geom_area(position = "stack") +
   geom_text(data = labels_reason_white_q,
             aes(x = academic_year, y = total_rate, label = percent(total_rate, accuracy = 0.1)),


### PR DESCRIPTION
## Summary
- Reference canonical suspension reason labels via `add_reason_label`
- Replace hard-coded reason strings in analyses with helper mapping
- Use helper-provided labels to drive plot colors and fill values

## Testing
- `Rscript --vanilla R/06_feature_reason_shares.R` *(fails: there is no package called 'arrow')*
- `Rscript --vanilla R/08_analysis_black_student_rates.R` *(fails: there is no package called 'arrow')*
- `Rscript --vanilla Analysis/01_trends.R` *(fails: there is no package called 'arrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c35b43f4a88331911ef8dbde48e586