### PR TITLE
Switch to canonical demographic fields

### DIFF
--- a/R/07_explore_trends.R
+++ b/R/07_explore_trends.R
@@ -35,7 +35,10 @@ order_quartile <- function(x) {
 
 # --- 3) Filter for Black Students Data ---------------------------------------
 black_students_data <- v6 %>%
-  filter(reporting_category == "RB") %>%
+  filter(
+    category_type == "Race/Ethnicity",
+    subgroup == "Black/African American"
+  ) %>%
   mutate(
     academic_year     = order_year(academic_year),
     black_prop_q_label= order_quartile(black_prop_q_label),

--- a/R/08_analysis_black_student_rates.R
+++ b/R/08_analysis_black_student_rates.R
@@ -21,7 +21,10 @@ v6 <- arrow::read_parquet(here::here("data-stage", "susp_v6_long.parquet")) %>%
 
 # --- 3) Filter for Black Students Data ---------------------------------------
 black_students_data <- v6 %>%
-  filter(reporting_category == "RB")
+  filter(
+    category_type == "Race/Ethnicity",
+    subgroup == "Black/African American"
+  )
 
 # ==============================================================================
 # PART 1: ANALYSIS BY BLACK STUDENT ENROLLMENT QUARTILES
@@ -60,7 +63,6 @@ p1_black_by_black <- ggplot(rate_by_black_quartile, aes(x = academic_year, y = s
 reason_rate_by_black_quartile <- black_students_data %>%
   # Most robust filter
   filter(
-    reporting_category == "RB",
     !is.na(black_prop_q_label),
     black_prop_q_label != "Unknown"
   ) %>%

--- a/R/22_build_v6_features.R
+++ b/R/22_build_v6_features.R
@@ -90,10 +90,11 @@ if (REBUILD_V6 || !file.exists(V6_FEAT_PARQ)) {
   # Roster
   roster <- v5 |> distinct(school_code, year)
   
-  # v5: one row per school-year (Total/All Students)
+  # v5: one row per school-year (All Students)
   v5_core <- if ("reporting_category" %in% names(v5)) {
     v5 %>%
-      filter(reporting_category %in% c("Total", "All Students", "TA")) %>%
+      mutate(subgroup = dplyr::coalesce(subgroup, canon_race_label(reporting_category))) %>%
+      filter(subgroup == "All Students") %>%
       distinct(school_code, year, .keep_all = TRUE)
   } else {
     v5 %>%


### PR DESCRIPTION
## Summary
- Replace legacy reporting category codes with canonical `category_type`/`subgroup` fields across analysis and feature scripts
- Standardize total-enrollment quartile script to use "All Students" labels
- Simplify v6 build to derive totals from canonical subgroup field

## Testing
- `Rscript R/22_build_v6_features.R` *(failed: missing package repository)*


------
https://chatgpt.com/codex/tasks/task_e_68c372c138e08331b55777551a11fb59