### PR TITLE
Use Native Hawaiian/Pacific Islander label across repository

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -53,7 +53,7 @@ year_levels <- v5 |>
   pull(academic_year)
 
 # ============ Race codes / labels ============
-allowed_codes <- c("Black/African American","White","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races","Hispanic/Latino")  # RL folds into RH
+allowed_codes <- c("Black/African American","White","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races","Hispanic/Latino")  # RL folds into RH
 
 # ============ Plot 1: Suspension RATES (All vs Race) ============
 # Statewide rate = sum(suspensions) / sum(enrollment) from campus-only rows

--- a/Analysis/04_rates_by_size_quartile_and_race.R
+++ b/Analysis/04_rates_by_size_quartile_and_race.R
@@ -52,7 +52,7 @@ df_total <- v5 %>%
   )
 
 # Races
-allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")
+allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
 df_race <- v5 %>%
   filter(canon_race_label(subgroup) %in% allowed_races,
          !is.na(enroll_q_label), enroll_q_label %in% q_keep) %>%

--- a/Analysis/05a_rates_by_race_by_locale.R
+++ b/Analysis/05a_rates_by_race_by_locale.R
@@ -50,7 +50,7 @@ df_total <- v5 %>%
 
 # Race-specific
 df_race <- v5 %>%
-  filter(subgroup %in% c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")) %>%
+  filter(subgroup %in% c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")) %>%
   mutate(race=canon_race_label(subgroup)) %>%
   filter(!is.na(race)) %>%
   group_by(academic_year, locale_simple, race) %>%

--- a/Analysis/06_rates_by_race_traditional_vs_other.R
+++ b/Analysis/06_rates_by_race_traditional_vs_other.R
@@ -90,7 +90,7 @@ df_total <- v5 %>%
          race = "All Students")
 
 # Race-specific
-allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")
+allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
 df_race <- v5 %>%
   filter(canon_race_label(subgroup) %in% allowed_races) %>%
   mutate(race = canon_race_label(subgroup)) %>%

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -66,7 +66,7 @@ all_other_note <- paste0("All other = Alternative (e.g., ", alt_found_pretty,
 # handled via shared canon_race_label() helper
 
 # --- 6) Aggregate to pooled rates by year × locale × race × group ------------
-allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races","All Students")
+allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races","All Students")
 
 df_all <- v5 %>%
   mutate(race = canon_race_label(subgroup)) %>%

--- a/Analysis/08_locale_all_years_all_races_one_graph_each.R
+++ b/Analysis/08_locale_all_years_all_races_one_graph_each.R
@@ -38,7 +38,7 @@ if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
 # --- 4) Race labels and Data Prep ---------------------------------------------
 # Keep TA + known races; drop RD (Not Reported)
-allowed_codes <- c("All Students","Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")
+allowed_codes <- c("All Students","Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
 
 df <- v5 %>%
   filter(subgroup %in% allowed_codes) %>%

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -51,7 +51,7 @@ LEVELS <- c("Elementary","Middle","High")
 
 # --- 4) Race labels & allowed codes ------------------------------------------
 # provided via canon_race_label() helper
-allowed_codes <- c("All Students","Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Pacific Islander","Two or More Races")
+allowed_codes <- c("All Students","Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
 
 # --- 5) Prep data -------------------------------------------------------------
 # Base long with race and year factor

--- a/Analysis/10_analysis_by_size_and_race.R
+++ b/Analysis/10_analysis_by_size_and_race.R
@@ -49,7 +49,7 @@ rates_by_size_race <- v5 %>%
       subgroup == "Asian" ~ "Asian",
       subgroup == "Filipino" ~ "Filipino",
       subgroup == "Hispanic/Latino" ~ "Hispanic",
-      subgroup == "Pacific Islander" ~ "Pacific Islander",
+      subgroup == "Native Hawaiian/Pacific Islander" ~ "Native Hawaiian/Pacific Islander",
       subgroup == "White" ~ "White",
       subgroup == "Two or More Races" ~ "Two or More Races",
       subgroup == "RD" ~ "Not Reported",

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -128,7 +128,7 @@ canon_race_label <- function(x) {
       "ri", "american indian", "alaska native",
       "american indian/alaska native", "native american"
     ) ~ "American Indian/Alaska Native",
-    x_clean %in% c("rp", "pacific islander", "native hawaiian") ~ "Pacific Islander",
+    x_clean %in% c("rp", "pacific islander", "native hawaiian") ~ "Native Hawaiian/Pacific Islander",
     x_clean %in% c(
       "rt", "two or more", "two or more races", "multirace",
       "multiple"


### PR DESCRIPTION
## Summary
- Canonicalize RP race code as "Native Hawaiian/Pacific Islander"
- Align `canon_label()` output with the same label
- Replace remaining "Pacific Islander" references across analysis scripts

## Testing
- `R -q --vanilla -e "install.packages('lintr', repos='https://cloud.r-project.org'); lintr::lint_dir('R'); lintr::lint_dir('Analysis')"` *(failed: package 'lintr' is not available for this version of R)*

------
https://chatgpt.com/codex/tasks/task_e_68c398e5c67083318ddd9d461abf6a1e