### PR TITLE
Standardize school level labels

### DIFF
--- a/Analysis/06_rates_by_race_traditional_vs_other.R
+++ b/Analysis/06_rates_by_race_traditional_vs_other.R
@@ -51,8 +51,8 @@ if (!length(year_levels)) stop("No TA rows to establish year order.")
 # Race label map (RD omitted; RL -> RH) handled by canon_race_label() helper
 
 # --- 4) Derive school group (Traditional vs All other) ------------------------
-# "Traditional" = Elementary/Middle/High (your strict 3-band)
-# "All other"   = Alternative + Other/Unknown (alt/continuation/comm day/juvenile court, atypical/unknown)
+# "Traditional" = Elementary/Middle/High (canonical levels)
+# "All other"   = Alternative + Other grade spans (alt/continuation/comm day/juvenile court, atypical/unknown)
 v5 <- v5 %>%
   mutate(
     school_group = dplyr::case_when(
@@ -72,8 +72,8 @@ alt_found <- alt_hint[alt_hint %in% unique(unlist(str_split(alt_examples, "\\W+"
 alt_found_pretty <- if (length(alt_found)) paste(alt_found, collapse=", ") else "alternative settings"
 
 all_other_note <- paste0(
-  "All other = Alternative (e.g., ", alt_found_pretty, 
-  ") plus schools with Other/Unknown grade spans."
+  "All other = Alternative (e.g., ", alt_found_pretty,
+  ") plus schools with Other grade spans."
 )
 
 # --- 5) Build pooled rates by year × school_group × race ----------------------

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -59,8 +59,8 @@ alt_examples <- v5 %>%
 alt_hint <- c("continuation","community day","juvenile court","alternative")
 alt_found <- alt_hint[alt_hint %in% unique(unlist(str_split(alt_examples, "\\W+")))]
 alt_found_pretty <- if (length(alt_found)) paste(alt_found, collapse=", ") else "alternative settings"
-all_other_note <- paste0("All other = Alternative (e.g., ", alt_found_pretty, 
-                         ") + schools with Other/Unknown grade spans.")
+all_other_note <- paste0("All other = Alternative (e.g., ", alt_found_pretty,
+                         ") + schools with Other grade spans.")
 
 # --- 5) Race labels -----------------------------------------------------------
 # handled via shared canon_race_label() helper

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -47,6 +47,7 @@ year_levels <- v5 %>%
 if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
 # Levels to include
+# canonical grade levels
 LEVELS <- c("Elementary","Middle","High")
 
 # --- 4) Race labels & allowed codes ------------------------------------------

--- a/Analysis/17_tail_by_grade-school_concentration_analysis.R
+++ b/Analysis/17_tail_by_grade-school_concentration_analysis.R
@@ -75,10 +75,8 @@ map_grade_level <- function(x) {
     str_detect(x_clean, "elementary|elem|primary|k.*5|k.*6") ~ "Elementary",
     str_detect(x_clean, "middle|junior|intermediate|6.*8|7.*8") ~ "Middle",
     str_detect(x_clean, "high|secondary|9.*12|senior") ~ "High",
-    str_detect(x_clean, "k.*12|ungraded|mixed|span") ~ "K-12/Mixed",
-    str_detect(x_clean, "adult|continuation") ~ "Adult/Alternative",
-    !is.na(x_clean) ~ "Other",
-    TRUE ~ "Unknown"
+    str_detect(x_clean, "adult|continuation") ~ "Alternative",
+    TRUE ~ "Other"
   )
 }
 

--- a/Analysis/18_comprehensive_suspension_rates_analysis.R
+++ b/Analysis/18_comprehensive_suspension_rates_analysis.R
@@ -156,16 +156,16 @@ analytic_data <- v5_complete %>%
     black_q = order_quartile(black_q),
     white_q = order_quartile(white_q),
     setting = factor(setting, levels = c("Traditional", "Non-traditional")),
-    grade_level = factor(grade_level, levels = c("Elementary", "Middle", "High", "K-12", "Alternative", "Other/Unknown"))
+    grade_level = factor(grade_level, levels = c("Elementary", "Middle", "High", "Other", "Alternative"))
   )
 
 # NOW add the diagnostic code:
 unknown_schools <- analytic_data %>%
-  filter(grade_level == "Other/Unknown") %>%
+  filter(grade_level == "Other") %>%
   count(school_level, sort = TRUE) %>%
   head(20)
 
-message("Top school level values classified as Other/Unknown:")
+message("Top school level values classified as Other:")
 print(unknown_schools)
 
 # -------------------------------------------------------------------------
@@ -347,7 +347,7 @@ create_grade_level_plot <- function() {
     filter(
       race_ethnicity == "Black/African American",
       setting == "Traditional",
-      grade_level %in% c("Elementary", "Middle", "High", "K-12")
+      grade_level %in% c("Elementary", "Middle", "High", "Other")
     ) %>%
     calc_summary_stats(year, grade_level, black_q)
   

--- a/R/05_feature_school_level.R
+++ b/R/05_feature_school_level.R
@@ -41,14 +41,16 @@ extract_min_max_grade <- function(gs) {
 get_min_grade <- function(x) vapply(x, function(s) extract_min_max_grade(s)[1], numeric(1))
 get_max_grade <- function(x) vapply(x, function(s) extract_min_max_grade(s)[2], numeric(1))
 
+LEVEL_LABELS <- c("Elementary", "Middle", "High", "Other", "Alternative")
+
 span_label <- function(gmin, gmax) {
-  if (is.na(gmin) || is.na(gmax)) return("Other/Unknown")
-  if (gmin <= 0 && gmax >= 12) return("K-12")
+  if (is.na(gmin) || is.na(gmax)) return("Other")
+  if (gmin <= 0 && gmax >= 12) return("Other")
   if (gmax <= 5) return("Elementary")
   if (gmin >= 6 && gmax <= 8) return("Middle")
   if (gmax >= 9) return("High")
   if (gmin <= 0 && gmax <= 8) return("Elementary")
-  "Other/Unknown"
+  "Other"
 }
 
 is_alt <- function(school_type) {
@@ -61,12 +63,14 @@ v4 <- v3_in %>%
   mutate(
     grade_min_num = get_min_grade(grades_served),
     grade_max_num = get_max_grade(grades_served),
-    
+
     # unified school level label
-    school_level = mapply(span_label, grade_min_num, grade_max_num),
+    school_level = factor(mapply(span_label, grade_min_num, grade_max_num),
+                          levels = LEVEL_LABELS),
 
     # Alternative override
-    school_level = if_else(is_alt(school_type), "Alternative", school_level),
+    school_level = if_else(is_alt(school_type), "Alternative", as.character(school_level)),
+    school_level = factor(school_level, levels = LEVEL_LABELS),
 
     # legacy aliases
     level_strict3 = school_level,


### PR DESCRIPTION
## Summary
- Consolidate grade level labels into a single canonical set and apply the mapping when building school-level features.
- Refresh analyses to reference the unified labels, clarifying that "All other" represents alternative or other grade spans.
- Align tail concentration and comprehensive rate analyses with the new label set.

## Testing
- ⚠️ `Rscript R/05_feature_school_level.R` *(fails: cannot open URL 'https://packagemanager.posit.co/cran/latest/src/contrib/PACKAGES')*


------
https://chatgpt.com/codex/tasks/task_e_68c398e8f5cc8331bb139cc988f31626