### PR TITLE
Use canonical suspension reason labels across analyses

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -170,10 +170,7 @@ if (has_prop_cols) {
       year_fct = factor(academic_year, levels = year_levels)
     )
   
-  reason_colors <- setNames(
-    c("#d62728", "#ff7f0e", "#2ca02c", "#1f77b4", "#9467bd", "#8c564b"),
-    reason_labels$reason_lab
-  )
+  reason_colors <- pal_reason
   
   reason_labels_all <- reason_share_by_year |> filter(!is.na(share))
   
@@ -188,7 +185,7 @@ if (has_prop_cols) {
       max.overlaps = Inf, direction = "y", nudge_x = NUDGE_X_LABELS,
       box.padding = 0.15, point.padding = 0.15, min.segment.length = 0
     ) +
-    scale_color_manual(values = reason_colors) +
+    scale_color_manual(values = reason_colors, breaks = names(reason_colors)) +
     scale_y_continuous(labels = percent_format(accuracy = 0.1), limits = c(0, NA),
                        expand = expansion(mult = c(0, 0.15))) +
     scale_x_discrete(expand = expansion(mult = c(0.02, 0.25))) +

--- a/R/06_feature_reason_shares.R
+++ b/R/06_feature_reason_shares.R
@@ -11,6 +11,9 @@ suppressPackageStartupMessages({
 
 message(">>> Running from project root: ", here::here())
 
+# canonical helpers (reason labels, palettes, etc.)
+source(here::here("R", "utils_keys_filters.R"))
+
 # ---- read v4 ---------------------------------------------------------------
 v4 <- arrow::read_parquet(here::here("data-stage", "susp_v4.parquet"))
 
@@ -46,7 +49,7 @@ v5 <- v4 %>%
 # optional: long format for analysis/plotting
 v5_long <- v5 %>%
   pivot_longer(
-    starts_with("prop_susp_"),
+    cols = dplyr::all_of(paste0("prop_susp_", reason_labels$reason)),
     names_to  = "reason",
     values_to = "prop_of_total_susp"
   ) %>%

--- a/R/08_analysis_black_student_rates.R
+++ b/R/08_analysis_black_student_rates.R
@@ -103,6 +103,7 @@ p2_reasons_by_black <- ggplot(reason_rate_by_black_quartile, aes(x = academic_ye
             aes(x = academic_year, y = total_rate, label = percent(total_rate, accuracy = 0.1)),
             vjust = -0.5, fontface = "bold", inherit.aes = FALSE) +
   facet_wrap(~ black_prop_q_label, ncol = 2) +
+  scale_fill_manual(values = pal_reason, breaks = names(pal_reason)) +
   scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
   labs(
     title = "Composition of Black Student Suspensions by School's Black Enrollment",
@@ -183,6 +184,7 @@ p4_reasons_by_white <- ggplot(reason_rate_by_white_quartile, aes(x = academic_ye
             aes(x = academic_year, y = total_rate, label = percent(total_rate, accuracy = 0.1)),
             vjust = -0.5, fontface = "bold", inherit.aes = FALSE) +
   facet_wrap(~ white_prop_q_label, ncol = 2) +
+  scale_fill_manual(values = pal_reason, breaks = names(pal_reason)) +
   scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
   labs(
     title = "Composition of Black Student Suspensions by School's White Enrollment",

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -39,9 +39,20 @@ reason_labels <- dplyr::tibble(
   )
 )
 
+# consistent color palette for suspension reasons
+pal_reason <- setNames(
+  c("#d62728", "#ff7f0e", "#2ca02c", "#1f77b4", "#9467bd", "#8c564b"),
+  reason_labels$reason_lab
+)
+
 # helper to append readable reason labels
 add_reason_label <- function(df, reason_col = "reason") {
-  dplyr::left_join(df, reason_labels, by = setNames("reason", reason_col))
+  reason_sym <- rlang::sym(reason_col)
+  dplyr::left_join(df, reason_labels, by = setNames("reason", reason_col)) %>%
+    dplyr::mutate(
+      !!reason_sym := factor(!!reason_sym, levels = reason_labels$reason),
+      reason_lab   = factor(reason_lab, levels = reason_labels$reason_lab)
+    )
 }
 
 # build canonical 14-digit CDS keys


### PR DESCRIPTION
## Summary
- centralize suspension reason labels and palette in utilities
- source utilities and use helper when reshaping reason columns
- apply shared reason palette in black student rate and trend analyses

## Testing
- `Rscript R/06_feature_reason_shares.R` *(fails: cannot download packages due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c398ea924483318afdc99e95ef7a75