### PR TITLE
Standardize locale levels

### DIFF
--- a/Analysis/05a_rates_by_race_by_locale.R
+++ b/Analysis/05a_rates_by_race_by_locale.R
@@ -115,17 +115,28 @@ plot_by_locale_set <- function(locales, title_suffix) {
 # --- 5) Render & save ---------------------------------------------------------
 outdir <- here::here("outputs"); dir.create(outdir, showWarnings = FALSE)
 
-p_city_suburb <- plot_by_locale_set(LOCALES_A, "City + Suburban")
-p_rural_town  <- plot_by_locale_set(LOCALES_B, paste(LOCALES_B, collapse=" + "))
+# Plot and save for each locale set using dynamic labels and filenames
+p_loc_set_a <- plot_by_locale_set(LOCALES_A, paste(LOCALES_A, collapse = " + "))
+p_loc_set_b <- plot_by_locale_set(LOCALES_B, paste(LOCALES_B, collapse = " + "))
 
-if (!is.null(p_city_suburb)) {
-  print(p_city_suburb)
-  ggsave(file.path(outdir, "A_rates_by_race_city_suburban.png"),
-         p_city_suburb, width=IMG_WIDTH, height=IMG_HEIGHT, dpi=IMG_DPI, bg="white")
+if (!is.null(p_loc_set_a)) {
+  print(p_loc_set_a)
+  fname_a <- paste0(
+    "A_rates_by_race_",
+    stringr::str_replace_all(tolower(paste(LOCALES_A, collapse = "_")), " ", "_"),
+    ".png"
+  )
+  ggsave(file.path(outdir, fname_a), p_loc_set_a,
+         width = IMG_WIDTH, height = IMG_HEIGHT, dpi = IMG_DPI, bg = "white")
 }
-if (!is.null(p_rural_town)) {
-  print(p_rural_town)
-  ggsave(file.path(outdir, "A_rates_by_race_rural_town.png"),
-         p_rural_town, width=IMG_WIDTH, height=IMG_HEIGHT, dpi=IMG_DPI, bg="white")
+if (!is.null(p_loc_set_b)) {
+  print(p_loc_set_b)
+  fname_b <- paste0(
+    "A_rates_by_race_",
+    stringr::str_replace_all(tolower(paste(LOCALES_B, collapse = "_")), " ", "_"),
+    ".png"
+  )
+  ggsave(file.path(outdir, fname_b), p_loc_set_b,
+         width = IMG_WIDTH, height = IMG_HEIGHT, dpi = IMG_DPI, bg = "white")
 }
 message("✓ Saved images to: ", outdir)

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -5,10 +5,14 @@ suppressPackageStartupMessages({
 
 SPECIAL_SCHOOL_CODES <- c("0000000", "0000001")
 
-# Canonical set of locale levels used across the project. To add or modify
-# locales, update this vector here rather than creating ad-hoc strings in
-# individual scripts.  The order of `locale_levels` drives plotting and factor
-# levels elsewhere, and `pal_locale` provides a consistent color mapping.
+# ---- Locale reference ---------------------------------------------------------
+#' Canonical locale levels and color palette.
+#'
+#' `locale_levels` enumerates the only accepted locale strings, in plotting
+#' order. `pal_locale` maps those levels to a consistent color palette.
+#' To add or modify locales, edit these objects here rather than creating
+#' ad-hoc strings or palettes elsewhere. All scripts should source this file
+#' to access `locale_levels` and `pal_locale`.
 locale_levels <- c("City", "Suburban", "Town", "Rural", "Unknown")
 pal_locale <- c(
   City     = "#0072B2",


### PR DESCRIPTION
## Summary
- Document canonical `locale_levels` and `pal_locale` in utilities
- Use dynamic subsets of `locale_levels` for locale-specific plots

## Testing
- `Rscript --vanilla -e "source('R/utils_keys_filters.R'); print(locale_levels); print(pal_locale)"`
- `Rscript --vanilla Analysis/05a_rates_by_race_by_locale.R` *(fails: there is no package called 'arrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c398eb88a083318a7d2c66f1af1544