### PR TITLE
Use canonical race labels in size-by-race analysis

### DIFF
--- a/Analysis/10_analysis_by_size_and_race.R
+++ b/Analysis/10_analysis_by_size_and_race.R
@@ -11,6 +11,9 @@ suppressPackageStartupMessages({
   library(ggrepel)
 })
 
+# Load helper functions
+source(here::here("R", "utils_keys_filters.R"))
+
 # --- 2) Load Data -------------------------------------------------------------
 message("Loading data...")
 v5 <- arrow::read_parquet(here::here("data-stage", "susp_v6_long.parquet"))
@@ -21,7 +24,8 @@ message("Preparing data for analysis...")
 rates_by_size_race <- v5 %>%
   filter(enroll_q_label != "Unknown", !is.na(enroll_q_label)) %>%
   filter(subgroup != "All Students") %>%
-  group_by(academic_year, enroll_q_label, subgroup) %>%
+  mutate(student_group = canon_race_label(coalesce(subgroup, reporting_category))) %>%
+  group_by(academic_year, enroll_q_label, student_group) %>%
   summarise(
     total_suspensions = sum(total_suspensions, na.rm = TRUE),
     cumulative_enrollment = sum(cumulative_enrollment, na.rm = TRUE),
@@ -29,34 +33,7 @@ rates_by_size_race <- v5 %>%
   ) %>%
   mutate(
     suspension_rate = if_else(cumulative_enrollment > 0, (total_suspensions / cumulative_enrollment) * 100, 0)
-  ) %>%
-  mutate(
-    student_group = case_when(
-##codex/update-pacific-islander-label-throughout-repo
-      reporting_category == "RB" ~ "Black",
-      reporting_category == "RI" ~ "American Indian",
-      reporting_category == "RA" ~ "Asian",
-      reporting_category == "RF" ~ "Filipino",
-      reporting_category == "RH" ~ "Hispanic",
-      reporting_category == "RP" ~ "Native Hawaiian/Pacific Islander",
-      reporting_category == "RW" ~ "White",
-      reporting_category == "RT" ~ "Two or More Races",
-      reporting_category == "RD" ~ "Not Reported",
-      TRUE ~ reporting_category
-##
-      subgroup == "Black/African American" ~ "Black",
-      subgroup == "American Indian/Alaska Native" ~ "American Indian",
-      subgroup == "Asian" ~ "Asian",
-      subgroup == "Filipino" ~ "Filipino",
-      subgroup == "Hispanic/Latino" ~ "Hispanic",
-      subgroup == "Native Hawaiian/Pacific Islander" ~ "Native Hawaiian/Pacific Islander",
-      subgroup == "White" ~ "White",
-      subgroup == "Two or More Races" ~ "Two or More Races",
-      subgroup == "RD" ~ "Not Reported",
-      TRUE ~ subgroup
-##main
-    )
-  )
+  ) 
 
 # --- 4) Create and Save Individual Plots --------------------------------------
 

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -110,7 +110,6 @@ assert_unique_campus <- function(df, year_col = "year", extra_keys = character()
 
 # assert uniqueness for a district-level frame
 # (function intentionally left for future implementation)
-##codex/update-pacific-islander-label-throughout-repo
 # map CRDC race codes to descriptive labels
 race_label <- function(code) dplyr::recode(
   code,


### PR DESCRIPTION
## Summary
- derive `student_group` via `canon_race_label(coalesce(subgroup, reporting_category))`
- load shared race label helper and drop local `case_when`
- remove obsolete Pacific Islander update comment

## Testing
- `Rscript --vanilla Analysis/10_analysis_by_size_and_race.R` *(fails: package 'here' is missing)*
- `R -q -e "lintr::lint('Analysis/10_analysis_by_size_and_race.R')"` *(fails: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c403cb2aec83319e0e916248717d9b