### PR TITLE
Centralize race filters using shared constant

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -52,9 +52,6 @@ year_levels <- v5 |>
   arrange(academic_year) |>
   pull(academic_year)
 
-# ============ Race codes / labels ============
-allowed_codes <- c("Black/African American","White","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races","Hispanic/Latino")  # RL folds into RH
-
 # ============ Plot 1: Suspension RATES (All vs Race) ============
 # Statewide rate = sum(suspensions) / sum(enrollment) from campus-only rows
 overall_rate_by_year <- v5 |>
@@ -72,9 +69,8 @@ overall_rate_by_year <- v5 |>
   )
 
 race_rate_by_year <- v5 |>
-  filter(subgroup %in% allowed_codes) |>
   mutate(race = canon_race_label(subgroup)) |>
-  filter(!is.na(race)) |>
+  filter(race %in% ALLOWED_RACES) |>
   group_by(academic_year, race) |>
   summarise(
     susp   = sum(total_suspensions, na.rm = TRUE),

--- a/Analysis/04_rates_by_size_quartile_and_race.R
+++ b/Analysis/04_rates_by_size_quartile_and_race.R
@@ -52,12 +52,12 @@ df_total <- v5 %>%
   )
 
 # Races
-allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
 df_race <- v5 %>%
-  filter(canon_race_label(subgroup) %in% allowed_races,
-         !is.na(enroll_q_label), enroll_q_label %in% q_keep) %>%
   mutate(race = canon_race_label(subgroup)) %>%
-  filter(!is.na(race)) %>%
+  filter(
+    race %in% setdiff(ALLOWED_RACES, "All Students"),
+    !is.na(enroll_q_label), enroll_q_label %in% q_keep
+  ) %>%
   group_by(academic_year, enroll_q_label, race) %>%
   summarise(
     susp   = sum(total_suspensions, na.rm=TRUE),

--- a/Analysis/06_rates_by_race_traditional_vs_other.R
+++ b/Analysis/06_rates_by_race_traditional_vs_other.R
@@ -90,11 +90,9 @@ df_total <- v5 %>%
          race = "All Students")
 
 # Race-specific
-allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
 df_race <- v5 %>%
-  filter(canon_race_label(subgroup) %in% allowed_races) %>%
   mutate(race = canon_race_label(subgroup)) %>%
-  filter(!is.na(race)) %>%
+  filter(race %in% setdiff(ALLOWED_RACES, "All Students")) %>%
   group_by(academic_year, school_group, race) %>%
   summarise(
     susp   = sum(total_suspensions, na.rm = TRUE),

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -66,11 +66,9 @@ all_other_note <- paste0("All other = Alternative (e.g., ", alt_found_pretty,
 # handled via shared canon_race_label() helper
 
 # --- 6) Aggregate to pooled rates by year × locale × race × group ------------
-allowed_races <- c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races","All Students")
-
 df_all <- v5 %>%
   mutate(race = canon_race_label(subgroup)) %>%
-  filter(!is.na(race), canon_race_label(subgroup) %in% allowed_races) %>%
+  filter(race %in% ALLOWED_RACES) %>%
   group_by(academic_year, locale_simple, school_group, race) %>%
   summarise(
     susp   = sum(total_suspensions, na.rm = TRUE),

--- a/Analysis/08_locale_all_years_all_races_one_graph_each.R
+++ b/Analysis/08_locale_all_years_all_races_one_graph_each.R
@@ -38,14 +38,12 @@ if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
 # --- 4) Race labels and Data Prep ---------------------------------------------
 # Keep TA + known races; drop RD (Not Reported)
-allowed_codes <- c("All Students","Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
-
 df <- v5 %>%
-  filter(subgroup %in% allowed_codes) %>%
   mutate(
     race = canon_race_label(subgroup),
     year_fct = factor(academic_year, levels = year_levels)
   ) %>%
+  filter(race %in% ALLOWED_RACES) %>%
   group_by(locale_simple, race, academic_year, year_fct) %>%
   summarise(
     susp   = sum(total_suspensions, na.rm = TRUE),

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -47,17 +47,16 @@ LEVELS <- c("Elementary","Middle","High")
 
 # --- 4) Race labels & allowed codes ------------------------------------------
 # provided via canon_race_label() helper
-allowed_codes <- c("All Students","Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")
 
 # --- 5) Prep data -------------------------------------------------------------
 # Base long with race and year factor
 base <- v5 %>%
-  filter(school_level %in% LEVELS,
-         subgroup %in% allowed_codes) %>%
+  filter(school_level %in% LEVELS) %>%
   mutate(
     race = canon_race_label(subgroup),
     year_fct = factor(academic_year, levels = year_levels)
-  )
+  ) %>%
+  filter(race %in% ALLOWED_RACES)
 
 # A) Aggregated across locales -> by LEVEL × RACE × YEAR
 df_level <- base %>%

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -154,6 +154,19 @@ canon_race_label <- function(x) {
   )
 }
 
+# Canonical race labels referenced across analysis scripts
+ALLOWED_RACES <- c(
+  "All Students",
+  "Black/African American",
+  "White",
+  "Hispanic/Latino",
+  "American Indian/Alaska Native",
+  "Asian",
+  "Filipino",
+  "Native Hawaiian/Pacific Islander",
+  "Two or More Races"
+)
+
 # Backward-compatible alias used by legacy scripts
 race_label <- canon_race_label
 ##main


### PR DESCRIPTION
## Summary
- Introduce `ALLOWED_RACES` in `utils_keys_filters.R` to hold canonical race labels
- Replace ad-hoc allowed code/race vectors in analysis scripts with the shared constant
- Ensure race filters apply `canon_race_label()` before comparison

## Testing
- ⚠️ `R -q -e "install.packages('lintr', repos='https://cloud.r-project.org')"` (403 Forbidden)
- ✅ `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE R -q -e "files <- c('R/utils_keys_filters.R','Analysis/01_trends.R','Analysis/08_locale_all_years_all_races_one_graph_each.R','Analysis/09_rates_by_level_and_by_level_locale.R','Analysis/04_rates_by_size_quartile_and_race.R','Analysis/06_rates_by_race_traditional_vs_other.R','Analysis/07_rates_trad_vs_other_by_race_by_locale.R'); for (f in files) { invisible(parse(f)); cat('parsed', f, '\n') }"`


------
https://chatgpt.com/codex/tasks/task_e_68c403b9b8d48331aca903419912570c