### PR TITLE
Handle Not Reported race label

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -133,7 +133,7 @@ p_rate_totals <- ggplot() +
     subtitle = "Suspension events per enrolled student (annual rate)",
     x = NULL, y = "Suspensions per student (%)",
     color = NULL,
-    caption = "Rate = total suspensions ÷ enrollment. RH=Hispanic/Latino; RI=American Indian/Alaska Native; RD excluded."
+    caption = "Rate = total suspensions ÷ enrollment. RH=Hispanic/Latino; RI=American Indian/Alaska Native; RD (Not Reported) excluded."
   ) +
   theme_minimal(base_size = 12) +
   theme(axis.text.x = element_text(angle = 35, hjust = 1))

--- a/Analysis/05b_rates_by_locale_facet_race_TWO.R
+++ b/Analysis/05b_rates_by_locale_facet_race_TWO.R
@@ -42,7 +42,7 @@ year_levels <- v5 %>%
 
 df_all <- v5 %>%
   mutate(race = canon_race_label(subgroup)) %>%
-  filter(!is.na(race)) %>%
+  filter(race %in% ALLOWED_RACES) %>%  # drop Not Reported
   group_by(academic_year, locale_simple, race) %>%
   summarise(susp=sum(total_suspensions, na.rm=TRUE),
             enroll=sum(cumulative_enrollment, na.rm=TRUE), .groups="drop") %>%

--- a/Analysis/10_analysis_by_size_and_race.R
+++ b/Analysis/10_analysis_by_size_and_race.R
@@ -23,8 +23,8 @@ message("Preparing data for analysis...")
 
 rates_by_size_race <- v5 %>%
   filter(enroll_q_label != "Unknown", !is.na(enroll_q_label)) %>%
-  filter(subgroup != "All Students") %>%
   mutate(student_group = canon_race_label(coalesce(subgroup, reporting_category))) %>%
+  filter(student_group %in% ALLOWED_RACES, student_group != "All Students") %>%
   group_by(academic_year, enroll_q_label, student_group) %>%
   summarise(
     total_suspensions = sum(total_suspensions, na.rm = TRUE),
@@ -33,36 +33,8 @@ rates_by_size_race <- v5 %>%
   ) %>%
   mutate(
     suspension_rate = if_else(cumulative_enrollment > 0, (total_suspensions / cumulative_enrollment) * 100, 0)
-##codex/remove-obsolete-race_label-function
-  ) %>%
-  mutate(
-    student_group = case_when(
-      reporting_category == "RB" ~ "Black",
-      reporting_category == "RI" ~ "American Indian",
-      reporting_category == "RA" ~ "Asian",
-      reporting_category == "RF" ~ "Filipino",
-      reporting_category == "RH" ~ "Hispanic",
-      reporting_category == "RP" ~ "Native Hawaiian/Pacific Islander",
-      reporting_category == "RW" ~ "White",
-      reporting_category == "RT" ~ "Two or More Races",
-      reporting_category == "RD" ~ "Not Reported",
-      TRUE ~ reporting_category
-##
-      subgroup == "Black/African American" ~ "Black",
-      subgroup == "American Indian/Alaska Native" ~ "American Indian",
-      subgroup == "Asian" ~ "Asian",
-      subgroup == "Filipino" ~ "Filipino",
-      subgroup == "Hispanic/Latino" ~ "Hispanic",
-      subgroup == "Native Hawaiian/Pacific Islander" ~ "Native Hawaiian/Pacific Islander",
-      subgroup == "White" ~ "White",
-      subgroup == "Two or More Races" ~ "Two or More Races",
-      subgroup == "RD" ~ "Not Reported",
-      TRUE ~ subgroup
-##main
-    )
   )
 
-  ) 
 ## main
 
 # --- 4) Create and Save Individual Plots --------------------------------------

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -151,6 +151,7 @@ canon_race_label <- function(x) {
       "multiple"
     ) ~ "Two or More Races",
     x_clean %in% c("rw", "white") ~ "White",
+    x_clean %in% c("rd", "not reported", "not_reported", "notreported") ~ "Not Reported",
     stringr::str_detect(x_clean, "gender|male|female") ~ "Sex",
     TRUE ~ NA_character_
   )
@@ -158,6 +159,7 @@ canon_race_label <- function(x) {
 #codex/remove-obsolete-race_label-function
 
 # Canonical race labels referenced across analysis scripts
+# "Not Reported" is mapped but intentionally omitted from this set
 ALLOWED_RACES <- c(
   "All Students",
   "Black/African American",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## R Project Setup with renv
 
-This project uses [`renv`](https://rstudio.github.io/renv/) to manage R package versions.  
+This project uses [`renv`](https://rstudio.github.io/renv/) to manage R package versions.
 
 ### First time setup
 ```r
@@ -15,3 +15,9 @@ renv::snapshot()
 
 # Just restore to sync packages with renv.lock
 renv::restore()
+```
+
+### Race label handling
+
+Race/ethnicity values are standardized with `canon_race_label()`. The CRDC code `RD` and text variants such as "Not Reported" map to a canonical "Not Reported" label. This category is excluded from visualizations by default and is filtered out in analysis scripts.
+


### PR DESCRIPTION
## Summary
- map CRDC code `RD` and "Not Reported" text to a canonical `Not Reported` label while keeping it out of `ALLOWED_RACES`
- filter out the new label in locale-faceted and size-by-race plots to avoid silent drops
- document handling of unreported race values in README and trend caption

## Testing
- `Rscript Analysis/05b_rates_by_locale_facet_race_TWO.R` *(failed: cannot download packages)*
- `Rscript Analysis/10_analysis_by_size_and_race.R` *(failed: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c40a3f7c948331b840bbd4f4790e3f