### PR TITLE
Recode suspension reason keys for trend plots

### DIFF
--- a/Analysis/02c_claude_black_rates_by_quartiles.R
+++ b/Analysis/02c_claude_black_rates_by_quartiles.R
@@ -112,6 +112,13 @@ create_category_rate_plot <- function(data, group_var, colors, title_suffix, leg
         names_to = "reason", values_to = "suspension_count"
       ) %>%
       mutate(reason = sub("^suspension_count_", "", reason)) %>%
+      mutate(reason = dplyr::case_match(
+        reason,
+        "violent_incident_injury"    ~ "violent_injury",
+        "violent_incident_no_injury" ~ "violent_no_injury",
+        "illicit_drug_related"       ~ "illicit_drug",
+        .default = reason
+      )) %>%
       group_by(academic_year, !!gsym, reason) %>%
       summarise(
         suspension_count = sum(suspension_count, na.rm = TRUE),
@@ -133,6 +140,13 @@ create_category_rate_plot <- function(data, group_var, colors, title_suffix, leg
         reason = sub("^prop_susp_", "", prop_name),
         reason_count = prop * total_suspensions
       ) %>%
+      mutate(reason = dplyr::case_match(
+        reason,
+        "violent_incident_injury"    ~ "violent_injury",
+        "violent_incident_no_injury" ~ "violent_no_injury",
+        "illicit_drug_related"       ~ "illicit_drug",
+        .default = reason
+      )) %>%
       group_by(academic_year, !!gsym, reason) %>%
       summarise(
         suspension_count = sum(reason_count, na.rm = TRUE),

--- a/R/07_explore_trends.R
+++ b/R/07_explore_trends.R
@@ -95,6 +95,13 @@ reason_rate_by_black_quartile <- black_students_data %>%
     names_to = "reason", values_to = "count"
   ) %>%
   mutate(reason = sub("^suspension_count_", "", reason)) %>%
+  mutate(reason = dplyr::case_match(
+    reason,
+    "violent_incident_injury"    ~ "violent_injury",
+    "violent_incident_no_injury" ~ "violent_no_injury",
+    "illicit_drug_related"       ~ "illicit_drug",
+    .default = reason
+  )) %>%
   add_reason_label("reason") %>%
   group_by(academic_year, black_prop_q_label, reason_lab) %>%
   summarise(
@@ -178,6 +185,13 @@ reason_rate_by_white_quartile <- black_students_data %>%
     names_to = "reason", values_to = "count"
   ) %>%
   mutate(reason = sub("^suspension_count_", "", reason)) %>%
+  mutate(reason = dplyr::case_match(
+    reason,
+    "violent_incident_injury"    ~ "violent_injury",
+    "violent_incident_no_injury" ~ "violent_no_injury",
+    "illicit_drug_related"       ~ "illicit_drug",
+    .default = reason
+  )) %>%
   add_reason_label("reason") %>%
   group_by(academic_year, white_prop_q_label, reason_lab) %>%
   summarise(


### PR DESCRIPTION
## Summary
- Recoded specific suspension reason identifiers to match canonical naming before labeling in trend plots.
- Applied recoding in both explore-trends and quartile analysis scripts to ensure consistent labels and palettes.

## Testing
- `Rscript R/07_explore_trends.R` *(fails: cannot access CRAN repository)*
- `Rscript Analysis/02c_claude_black_rates_by_quartiles.R` *(fails: cannot access CRAN repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c414457b148331b2bd7c9a7a9090f8