### PR TITLE
Recoded suspension reason categories

### DIFF
--- a/Analysis/02c_claude_black_rates_by_quartiles.R
+++ b/Analysis/02c_claude_black_rates_by_quartiles.R
@@ -112,6 +112,13 @@ create_category_rate_plot <- function(data, group_var, colors, title_suffix, leg
         names_to = "reason", values_to = "suspension_count"
       ) %>%
       mutate(reason = sub("^suspension_count_", "", reason)) %>%
+      mutate(reason = dplyr::case_match(
+        reason,
+        "violent_incident_injury"    ~ "violent_injury",
+        "violent_incident_no_injury" ~ "violent_no_injury",
+        "illicit_drug_related"       ~ "illicit_drug",
+        .default = reason
+      )) %>%
       group_by(academic_year, !!gsym, reason) %>%
       summarise(
         suspension_count = sum(suspension_count, na.rm = TRUE),
@@ -133,13 +140,20 @@ create_category_rate_plot <- function(data, group_var, colors, title_suffix, leg
         reason = sub("^prop_susp_", "", prop_name),
         reason_count = prop * total_suspensions
       ) %>%
+      mutate(reason = dplyr::case_match(
+        reason,
+        "violent_incident_injury"    ~ "violent_injury",
+        "violent_incident_no_injury" ~ "violent_no_injury",
+        "illicit_drug_related"       ~ "illicit_drug",
+        .default = reason
+      )) %>%
       group_by(academic_year, !!gsym, reason) %>%
       summarise(
         suspension_count = sum(reason_count, na.rm = TRUE),
         total_enrollment = sum(cumulative_enrollment, na.rm = TRUE),
         .groups = "drop"
       ) %>%
-      add_reason_label() %>%
+      add_reason_label("reason") %>%
       mutate(
         reason_rate = if_else(total_enrollment > 0, suspension_count / total_enrollment, NA_real_),
         year_fct    = factor(academic_year, levels = year_levels)

--- a/R/07_explore_trends.R
+++ b/R/07_explore_trends.R
@@ -95,6 +95,13 @@ reason_rate_by_black_quartile <- black_students_data %>%
     names_to = "reason", values_to = "count"
   ) %>%
   mutate(reason = sub("^suspension_count_", "", reason)) %>%
+  mutate(reason = dplyr::case_match(
+    reason,
+    "violent_incident_injury"    ~ "violent_injury",
+    "violent_incident_no_injury" ~ "violent_no_injury",
+    "illicit_drug_related"       ~ "illicit_drug",
+    .default = reason
+  )) %>%
   add_reason_label("reason") %>%
   group_by(academic_year, black_prop_q_label, reason_lab) %>%
   summarise(
@@ -178,6 +185,13 @@ reason_rate_by_white_quartile <- black_students_data %>%
     names_to = "reason", values_to = "count"
   ) %>%
   mutate(reason = sub("^suspension_count_", "", reason)) %>%
+  mutate(reason = dplyr::case_match(
+    reason,
+    "violent_incident_injury"    ~ "violent_injury",
+    "violent_incident_no_injury" ~ "violent_no_injury",
+    "illicit_drug_related"       ~ "illicit_drug",
+    .default = reason
+  )) %>%
   add_reason_label("reason") %>%
   group_by(academic_year, white_prop_q_label, reason_lab) %>%
   summarise(


### PR DESCRIPTION
## Summary
- Recode verbose suspension reason identifiers to concise forms before labeling in trend and quartile rate plots
- Apply consistent reason recoding in helper function for category rate plots

## Testing
- `Rscript R/07_explore_trends.R` *(failed: unable to download packages from Posit CRAN mirror)*
- `Rscript Analysis/02c_claude_black_rates_by_quartiles.R` *(failed: unable to download packages from Posit CRAN mirror)*

------
https://chatgpt.com/codex/tasks/task_e_68c4157ba8648331910a98a7bfd57367