### PR TITLE
Document Not Reported race handling

### DIFF
--- a/Analysis/01_trends.R
+++ b/Analysis/01_trends.R
@@ -133,7 +133,6 @@ p_rate_totals <- ggplot() +
     subtitle = "Suspension events per enrolled student (annual rate)",
     x = NULL, y = "Suspensions per student (%)",
     color = NULL,
-##codex/add-canonical-label-for-rd-in-filters
     caption = "Rate = total suspensions ÷ enrollment. RH=Hispanic/Latino; RI=American Indian/Alaska Native. 'Not Reported' omitted."
 
   ) +

--- a/Analysis/10_analysis_by_size_and_race.R
+++ b/Analysis/10_analysis_by_size_and_race.R
@@ -24,9 +24,8 @@ message("Preparing data for analysis...")
 # Build rates by race and enrollment quartile, excluding "Not Reported"
 rates_by_size_race <- v5 %>%
   filter(enroll_q_label != "Unknown", !is.na(enroll_q_label)) %>%
-  mutate(student_group = canon_race_label(coalesce(subgroup, reporting_category))) %>%
-##codex/add-canonical-label-for-rd-in-filters
-  filter(student_group %in% setdiff(ALLOWED_RACES, "All Students")) %>%
+    mutate(student_group = canon_race_label(coalesce(subgroup, reporting_category))) %>%
+    filter(student_group %in% setdiff(ALLOWED_RACES, "All Students")) %>%
 
   group_by(academic_year, enroll_q_label, student_group) %>%
   summarise(
@@ -37,8 +36,6 @@ rates_by_size_race <- v5 %>%
   mutate(
     suspension_rate = if_else(cumulative_enrollment > 0, (total_suspensions / cumulative_enrollment) * 100, 0)
   )
-
-##codex/add-canonical-label-for-rd-in-filters
 
 ## main
 

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -151,7 +151,7 @@ canon_race_label <- function(x) {
       "multiple"
     ) ~ "Two or More Races",
     x_clean %in% c("rw", "white") ~ "White",
-##codex/add-canonical-label-for-rd-in-filters
+    # Map CRDC code RD and similar strings to the canonical "Not Reported" label
     x_clean %in% c("rd", "not reported", "not_reported", "notreported") ~ "Not Reported",
 
     stringr::str_detect(x_clean, "gender|male|female") ~ "Sex",

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ renv::snapshot()
 renv::restore()
 ```
 
-##codex/add-canonical-label-for-rd-in-filters
 ### Canonical race labels
 
-`R/utils_keys_filters.R` defines `canon_race_label()` and `ALLOWED_RACES` used across analyses. The function now maps CRDC code `RD` and strings such as "Not Reported" to the canonical label "Not Reported." This group is recognized for completeness but excluded from plots to avoid conflating missing data with student populations.
+`R/utils_keys_filters.R` defines `canon_race_label()` and `ALLOWED_RACES` used across analyses. The function maps CRDC code `RD` and strings such as "Not Reported" to the canonical label "Not Reported." This category is tracked for completeness but omitted from plots to avoid conflating missing data with student populations.
 
 


### PR DESCRIPTION
## Summary
- Describe canonical race labels, mapping CRDC code `RD` and "Not Reported" strings to canonical "Not Reported"
- Clarify "Not Reported" mapping in `canon_race_label()`
- Remove leftover codex markers from analysis scripts

## Testing
- `Rscript -e "source('R/utils_keys_filters.R')"` *(failed: unable to download renv dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c41f5fb96c8331817078ea88f05f15