### PR TITLE
Rename v5 variables to v6 for susp_v6_long

### DIFF
--- a/Analysis/02c_claude_black_rates_by_quartiles.R
+++ b/Analysis/02c_claude_black_rates_by_quartiles.R
@@ -24,27 +24,27 @@ white_quartile_colors <- setNames(
 
 # --- 2) Load + guards ---------------------------------------------------------
 message("Loading data...")
-v5 <- arrow::read_parquet(here::here("data-stage","susp_v6_long.parquet")) %>%
+v6 <- arrow::read_parquet(here::here("data-stage","susp_v6_long.parquet")) %>%
   build_keys() %>%            # adds cds_district, cds_school (canonical keys)
   filter_campus_only()        # drops fake schools + special codes
 
 need_cols <- c("subgroup","academic_year",
                "total_suspensions","cumulative_enrollment",
                "black_prop_q","white_prop_q")
-missing <- setdiff(need_cols, names(v5))
-if (length(missing)) stop("Missing in v5: ", paste(missing, collapse=", "))
+missing <- setdiff(need_cols, names(v6))
+if (length(missing)) stop("Missing in v6: ", paste(missing, collapse=", "))
 
 # make sure readable quartile labels exist using shared helper
-if (!"black_prop_q_label" %in% names(v5)) v5 <- v5 %>% mutate(black_prop_q_label = get_quartile_label(black_prop_q, "Black"))
-if (!"white_prop_q_label" %in% names(v5)) v5 <- v5 %>% mutate(white_prop_q_label = get_quartile_label(white_prop_q, "White"))
+if (!"black_prop_q_label" %in% names(v6)) v6 <- v6 %>% mutate(black_prop_q_label = get_quartile_label(black_prop_q, "Black"))
+if (!"white_prop_q_label" %in% names(v6)) v6 <- v6 %>% mutate(white_prop_q_label = get_quartile_label(white_prop_q, "White"))
 
 # order x-axis by TA years that actually have enrollment
-year_levels <- v5 %>%
+year_levels <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students", cumulative_enrollment > 0) %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 # restrict to Black rows for all calculations
-black_students_data <- v5 %>% filter(subgroup == "Black/African American")
+black_students_data <- v6 %>% filter(subgroup == "Black/African American")
 
 # Reason columns: prefer *_count columns if present; otherwise derive from proportions
 has_count_cols <- all(c(
@@ -54,9 +54,9 @@ has_count_cols <- all(c(
   "suspension_count_weapons_possession",
   "suspension_count_illicit_drug_related",
   "suspension_count_other_reasons"
-) %in% names(v5))
+) %in% names(v6))
 
-  prop_cols <- grep("^prop_susp_", names(v5), value = TRUE)
+  prop_cols <- grep("^prop_susp_", names(v6), value = TRUE)
 
 # --- 3) Total Rate Plot helper -----------------------------------------------
 create_total_rate_plot <- function(data, group_var, colors, title_suffix, legend_title) {
@@ -159,7 +159,7 @@ create_category_rate_plot <- function(data, group_var, colors, title_suffix, leg
         year_fct    = factor(academic_year, levels = year_levels)
       )
   } else {
-    stop("No reason data available: neither *_count nor prop_susp_* columns exist in v5.")
+    stop("No reason data available: neither *_count nor prop_susp_* columns exist in v6.")
   }
   
   df2 <- plot_data %>% filter(!is.na(reason_rate))

--- a/Analysis/04_rates_by_size_quartile_and_race.R
+++ b/Analysis/04_rates_by_size_quartile_and_race.R
@@ -16,15 +16,15 @@ HALO_ALPHA    <- 0.2 # label box fill transparency (0=clear, 1=opaque)
 RACE_SET <- NULL  # e.g., c("All Students","Hispanic/Latino","Black/African American","White","Asian")
 
 # ======= data load & guards =======
-v5 <- read_parquet(here("data-stage","susp_v6_long.parquet"))
+v6 <- read_parquet(here("data-stage","susp_v6_long.parquet"))
 
 need <- c("subgroup","academic_year","total_suspensions","cumulative_enrollment","enroll_q_label")
-miss <- setdiff(need, names(v5))
-if (length(miss)) stop("Missing columns in v5: ", paste(miss, collapse=", "),
+miss <- setdiff(need, names(v6))
+if (length(miss)) stop("Missing columns in v6: ", paste(miss, collapse=", "),
                        "\nRe-run 03_feature_size_quartiles_TA.R and downstream.")
 
 # Year order
-year_levels <- v5 %>% filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
+year_levels <- v6 %>% filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 # Enrollment quartiles of interest
@@ -39,7 +39,7 @@ shape_quart <- c("Q1 (Smallest)"=16, "Q4 (Largest)"=17)  # circle vs triangle
 
 # ======= aggregate: pooled rates by year × quartile × race =======
 # Total (All Students) from TA
-df_total <- v5 %>%
+df_total <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students", !is.na(enroll_q_label), enroll_q_label %in% q_keep) %>%
   group_by(academic_year, enroll_q_label) %>%
   summarise(
@@ -53,7 +53,7 @@ df_total <- v5 %>%
   )
 
 # Races
-df_race <- v5 %>%
+df_race <- v6 %>%
   mutate(race = canon_race_label(subgroup)) %>%
   filter(
     race %in% setdiff(ALLOWED_RACES, "All Students"),

--- a/Analysis/05a_rates_by_race_by_locale.R
+++ b/Analysis/05a_rates_by_race_by_locale.R
@@ -27,21 +27,21 @@ set.seed(42)
 
 # --- 3) Load & prepare --------------------------------------------------------
 message("Loading data…")
-v5_path <- here::here("data-stage","susp_v6_long.parquet")
-if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
-v5 <- arrow::read_parquet(v5_path)
+v6_path <- here::here("data-stage","susp_v6_long.parquet")
+if (!file.exists(v6_path)) stop("Data file not found: ", v6_path)
+v6 <- arrow::read_parquet(v6_path)
 
 need <- c("subgroup","academic_year","locale_simple",
           "total_suspensions","cumulative_enrollment")
-miss <- setdiff(need, names(v5))
+miss <- setdiff(need, names(v6))
 if (length(miss)) stop("Missing columns: ", paste(miss, collapse=", "))
 
-year_levels <- v5 %>%
+year_levels <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 # All Students
-df_total <- v5 %>%
+df_total <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   group_by(academic_year, locale_simple) %>%
   summarise(susp=sum(total_suspensions, na.rm=TRUE),
@@ -49,7 +49,7 @@ df_total <- v5 %>%
   mutate(rate=if_else(enroll>0, susp/enroll, NA_real_), race="All Students")
 
 # Race-specific
-df_race <- v5 %>%
+df_race <- v6 %>%
   filter(subgroup %in% c("Black/African American","White","Hispanic/Latino","Hispanic/Latino","American Indian/Alaska Native","Asian","Filipino","Native Hawaiian/Pacific Islander","Two or More Races")) %>%
   mutate(race=canon_race_label(subgroup)) %>%
   filter(!is.na(race)) %>%

--- a/Analysis/05b_rates_by_locale_facet_race_TWO.R
+++ b/Analysis/05b_rates_by_locale_facet_race_TWO.R
@@ -27,20 +27,20 @@ set.seed(42)
 
 # --- 3) Load & prepare --------------------------------------------------------
 message("Loading and preparing data…")
-v5_path <- here::here("data-stage","susp_v6_long.parquet")
-if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
-v5 <- arrow::read_parquet(v5_path)
+v6_path <- here::here("data-stage","susp_v6_long.parquet")
+if (!file.exists(v6_path)) stop("Data file not found: ", v6_path)
+v6 <- arrow::read_parquet(v6_path)
 
 need <- c("subgroup","academic_year","locale_simple",
           "total_suspensions","cumulative_enrollment")
-miss <- setdiff(need, names(v5))
+miss <- setdiff(need, names(v6))
 if (length(miss)) stop("Missing required columns: ", paste(miss, collapse=", "))
 
-year_levels <- v5 %>%
+year_levels <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
-df_all <- v5 %>%
+df_all <- v6 %>%
   mutate(race = canon_race_label(subgroup)) %>%
   filter(race %in% ALLOWED_RACES) %>%  # drop Not Reported
   group_by(academic_year, locale_simple, race) %>%

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -29,22 +29,22 @@ set.seed(42)
 
 # --- 3) Load & guards ---------------------------------------------------------
 message("Loading data…")
-v5_path <- here::here("data-stage","susp_v6_long.parquet")
-if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
-v5 <- arrow::read_parquet(v5_path)
+v6_path <- here::here("data-stage","susp_v6_long.parquet")
+if (!file.exists(v6_path)) stop("Data file not found: ", v6_path)
+v6 <- arrow::read_parquet(v6_path)
 
 need <- c("subgroup","academic_year","locale_simple","school_level",
           "school_type","total_suspensions","cumulative_enrollment")
-miss <- setdiff(need, names(v5))
+miss <- setdiff(need, names(v6))
 if (length(miss)) stop("Missing required columns: ", paste(miss, collapse=", "))
 
-year_levels <- v5 %>%
+year_levels <- v6 %>%
   dplyr::filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   dplyr::distinct(academic_year) %>% dplyr::arrange(academic_year) %>% dplyr::pull(academic_year)
 if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
 # --- 4) School group & caption note ------------------------------------------
-v5 <- v5 %>%
+v6 <- v6 %>%
   mutate(
     school_group = dplyr::case_when(
       school_level %in% c("Elementary","Middle","High") ~ "Traditional",
@@ -53,7 +53,7 @@ v5 <- v5 %>%
   )
 
 # Build a short hint of what “All other” includes
-alt_examples <- v5 %>%
+alt_examples <- v6 %>%
   filter(school_level == "Alternative") %>%
   distinct(school_type) %>% pull() %>% tolower()
 alt_hint <- c("continuation","community day","juvenile court","alternative")
@@ -66,7 +66,7 @@ all_other_note <- paste0("All other = Alternative (e.g., ", alt_found_pretty,
 # handled via shared canon_race_label() helper
 
 # --- 6) Aggregate to pooled rates by year × locale × race × group ------------
-df_all <- v5 %>%
+df_all <- v6 %>%
   mutate(race = canon_race_label(subgroup)) %>%
   filter(race %in% ALLOWED_RACES) %>%
   group_by(academic_year, locale_simple, school_group, race) %>%

--- a/Analysis/08_locale_all_years_all_races_one_graph_each.R
+++ b/Analysis/08_locale_all_years_all_races_one_graph_each.R
@@ -21,24 +21,24 @@ IMG_DPI           <- 300
 set.seed(42)
 
 # --- 3) Load & guards ---------------------------------------------------------
-v5_path <- here::here("data-stage","susp_v6_long.parquet")
-if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
-v5 <- arrow::read_parquet(v5_path)
+v6_path <- here::here("data-stage","susp_v6_long.parquet")
+if (!file.exists(v6_path)) stop("Data file not found: ", v6_path)
+v6 <- arrow::read_parquet(v6_path)
 
 need <- c("subgroup","academic_year","locale_simple",
           "total_suspensions","cumulative_enrollment")
-miss <- setdiff(need, names(v5))
+miss <- setdiff(need, names(v6))
 if (length(miss)) stop("Missing columns: ", paste(miss, collapse=", "))
 
 # Year order driven by TA
-year_levels <- v5 %>%
+year_levels <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 
 # --- 4) Race labels and Data Prep ---------------------------------------------
 # Keep TA + known races; drop "Not Reported" (RD)
-df <- v5 %>%
+df <- v6 %>%
   mutate(
     race = canon_race_label(subgroup),
     year_fct = factor(academic_year, levels = year_levels)

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -26,17 +26,17 @@ IMG_DPI     <- 300
 set.seed(42)
 
 # --- 3) Load & guards ---------------------------------------------------------
-v5_path <- here::here("data-stage","susp_v6_long.parquet")
-if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
-v5 <- arrow::read_parquet(v5_path)
+v6_path <- here::here("data-stage","susp_v6_long.parquet")
+if (!file.exists(v6_path)) stop("Data file not found: ", v6_path)
+v6 <- arrow::read_parquet(v6_path)
 
 need <- c("subgroup","academic_year","locale_simple","school_level",
           "total_suspensions","cumulative_enrollment")
-miss <- setdiff(need, names(v5))
+miss <- setdiff(need, names(v6))
 if (length(miss)) stop("Missing columns: ", paste(miss, collapse=", "))
 
 # Academic year order driven by TA
-year_levels <- v5 %>%
+year_levels <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 if (!length(year_levels)) stop("No TA rows to establish academic year order.")
@@ -50,7 +50,7 @@ LEVELS <- c("Elementary","Middle","High")
 
 # --- 5) Prep data -------------------------------------------------------------
 # Base long with race and year factor
-base <- v5 %>%
+base <- v6 %>%
   filter(school_level %in% LEVELS) %>%
   mutate(
     race = canon_race_label(subgroup),

--- a/Analysis/10_analysis_by_size_and_race.R
+++ b/Analysis/10_analysis_by_size_and_race.R
@@ -16,13 +16,13 @@ source(here::here("R", "utils_keys_filters.R"))
 
 # --- 2) Load Data -------------------------------------------------------------
 message("Loading data...")
-v5 <- arrow::read_parquet(here::here("data-stage", "susp_v6_long.parquet"))
+v6 <- arrow::read_parquet(here::here("data-stage", "susp_v6_long.parquet"))
 
 # --- 3) Prepare Data for Plotting ---------------------------------------------
 message("Preparing data for analysis...")
 
 # Build rates by race and enrollment quartile, excluding "Not Reported"
-rates_by_size_race <- v5 %>%
+rates_by_size_race <- v6 %>%
   filter(enroll_q_label != "Unknown", !is.na(enroll_q_label)) %>%
   mutate(student_group = canon_race_label(coalesce(subgroup, reporting_category))) %>%
 ##codex/add-canonical-label-for-rd-in-filters

--- a/Analysis/10_eda_hotspots_and_trends.R
+++ b/Analysis/10_eda_hotspots_and_trends.R
@@ -38,28 +38,28 @@ trend_dir_spearman <- function(v) {
 }
 
 # --- Load & guards -----------------------------------------------------------
-v5_path <- here("data-stage", "susp_v6_long.parquet")
-if (!file.exists(v5_path)) stop("Data file not found: ", v5_path)
-v5 <- read_parquet(v5_path)
+v6_path <- here("data-stage", "susp_v6_long.parquet")
+if (!file.exists(v6_path)) stop("Data file not found: ", v6_path)
+v6 <- read_parquet(v6_path)
 
 required_cols <- c("subgroup","academic_year","total_suspensions",
                    "cumulative_enrollment","school_level","locale_simple")
-missing_cols <- setdiff(required_cols, names(v5))
+missing_cols <- setdiff(required_cols, names(v6))
 if (length(missing_cols)) stop("Missing required columns: ", paste(missing_cols, collapse = ", "))
 
 # Order academic years (driven by TA)
-year_levels <- v5 %>%
+year_levels <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull()
 if (!length(year_levels)) stop("No TA rows found to anchor academic_year order.")
 
 # Optional: drop Unknown locale up front
 if (isTRUE(DROP_UNKNOWN_LOCALE)) {
-  v5 <- v5 %>% filter(locale_simple != "Unknown")
+  v6 <- v6 %>% filter(locale_simple != "Unknown")
 }
 
 # --- Base with labels & factors ---------------------------------------------
-base <- v5 %>%
+base <- v6 %>%
   mutate(
     race     = canon_race_label(subgroup),
     year_fct = factor(academic_year, levels = year_levels, ordered = TRUE)
@@ -71,7 +71,7 @@ base <- v5 %>%
   )
 
 # Small memory cleanup
-rm(v5); invisible(gc())
+rm(v6); invisible(gc())
 
 # --- Outputs: directory + timestamp (used throughout) ------------------------
 outdir <- here("outputs"); dir.create(outdir, showWarnings = FALSE, recursive = TRUE)

--- a/Analysis/18_comprehensive_suspension_rates_analysis.R
+++ b/Analysis/18_comprehensive_suspension_rates_analysis.R
@@ -21,7 +21,7 @@ DATA_STAGE <- here("data-stage")
 V6_LONG_PARQ <- file.path(DATA_STAGE, "susp_v6_long.parquet")
 V6F_PARQ <- file.path(DATA_STAGE, "susp_v6_features.parquet")
 stopifnot(file.exists(V6_LONG_PARQ), file.exists(V6F_PARQ))
-v5 <- read_parquet(V6_LONG_PARQ)
+v6 <- read_parquet(V6_LONG_PARQ)
 v6_features <- read_parquet(V6F_PARQ)
 
 # Output setup
@@ -106,7 +106,7 @@ reach_race_cols <- c(
 message("=== APPLYING DIRECT GRADE LEVEL FIX ===")
 
 # Step 1: Get everything directly from v6 long (which has all the data we need)
-v5_complete <- v5 %>%
+v6_complete <- v6 %>%
   clean_names() %>%
   build_keys() %>%
   filter_campus_only() %>%
@@ -144,7 +144,7 @@ v6_traditional <- v6_features %>%
   distinct()
 
 # Step 3: Join and finalize
-analytic_data <- v5_complete %>%
+analytic_data <- v6_complete %>%
   left_join(v6_traditional, by = c("school_code", "year")) %>%
   mutate(
     is_traditional = ifelse(is.na(is_traditional), TRUE, is_traditional),


### PR DESCRIPTION
## Summary
- rename v5 variables to v6 across Analysis scripts using susp_v6_long.parquet
- remove leftover v5 references in comments and messages

## Testing
- `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE Rscript -e "parse('Analysis/01_trends.R')"`
- `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE Rscript -e "parse('Analysis/18_comprehensive_suspension_rates_analysis.R')"`


------
https://chatgpt.com/codex/tasks/task_e_68c41f323d808331a3d3205ce80bad3f