### PR TITLE
Write v3 parquet file and log output

### DIFF
--- a/R/04_feature_black_prop_quartiles.R
+++ b/R/04_feature_black_prop_quartiles.R
@@ -133,5 +133,8 @@ rb_rw_ta %>%
   ) %>%
   print(n = 60) # All should be FALSE
 
-invisible(TRUE)
 # --- write output -----------------------------------------------------------
+arrow::write_parquet(v3, here::here("data-stage", "susp_v3.parquet"))
+message(">>> 04_feature_black_prop_quartiles: wrote susp_v3.parquet")
+
+invisible(TRUE)


### PR DESCRIPTION
## Summary
- Persist v3 data frame to `data-stage/susp_v3.parquet`.
- Log confirmation that the file was written in `04_feature_black_prop_quartiles`.

## Testing
- `Rscript R/04_feature_black_prop_quartiles.R` *(fails: cannot access package repository)*


------
https://chatgpt.com/codex/tasks/task_e_68c434e5e5dc8331a559b909d60dbe63