### PR TITLE
Conditionally run charter drop step for TA pipeline

### DIFF
--- a/run_pipeline.R
+++ b/run_pipeline.R
@@ -31,7 +31,7 @@ scripts <- c(
   "R/00_paths.R",
   "R/01_ingest_v0.R",
   "R/02_feature_locale_simple.R",
-  "R/02b_drop_charter_all.R",
+  if (USE_TA) "R/02b_drop_charter_all.R",
   if (USE_TA) "R/03_feature_size_quartiles_TA.R" else "R/03_feature_size_quartiles.R",
   "R/04_feature_black_prop_quartiles.R",
   "R/05_feature_school_level.R",   # merged version; NOT the archived 'school_levels'


### PR DESCRIPTION
## Summary
- Only run `R/02b_drop_charter_all.R` when TA feature pipeline is selected, skipping unnecessary charter filtering for the non-TA path

## Testing
- `Rscript run_pipeline.R` *(fails: cannot download packages from CRAN mirror)*

------
https://chatgpt.com/codex/tasks/task_e_68c4399dc7688331b66da7cc881e1942