### PR TITLE
Remove redundant v6 feature build call

### DIFF
--- a/run_all.R
+++ b/run_all.R
@@ -19,7 +19,6 @@ run <- function(f) {
 
 # 1) Core build (00–06, with USE_TA toggle inside run_pipeline.R)
 run("run_pipeline.R")
-run("R/22_build_v6_features.R")
 
 # 2) EDA + merge steps that produce non-intersectional exports used by tail analysis
 #    (these paths match what you showed; adjust if your files live elsewhere)


### PR DESCRIPTION
## Summary
- Remove explicit call to `R/22_build_v6_features.R` from `run_all.R` since `run_pipeline.R` already sources it

## Testing
- `Rscript --vanilla run_all.R` *(fails: raw file not found `data-raw/copy_CDE_suspensions_1718-2324_sc_race.xlsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68c439a5f89c8331a79aefc10aa656cf