### PR TITLE
Exclude gender rows from subgroup analyses

### DIFF
--- a/R/23_rates_by_year_quartile_subgroup.R
+++ b/R/23_rates_by_year_quartile_subgroup.R
@@ -52,7 +52,7 @@ long_src <- read_parquet(V6L_PARQ) %>% clean_names() %>%
                                   canon_race_label(subgroup)),
     rate        = as.numeric(rate)
   ) %>%
-  filter(!is.na(subgroup))
+  filter(!is.na(subgroup), subgroup != "Sex")
 
 # --- Join keys + filter to traditional ---------------------------------------
 analytic <- long_src %>%

--- a/R/24_rates_pooled_by_year_blackquartile.R
+++ b/R/24_rates_pooled_by_year_blackquartile.R
@@ -46,7 +46,7 @@ long_counts <- read_parquet(V6L_PARQ) %>% clean_names() %>%
     num         = as.numeric(num),
     den         = as.numeric(den)
   ) %>%
-  filter(!is.na(subgroup))
+  filter(!is.na(subgroup), subgroup != "Sex")
 
 # ───────────────────────── Join keys + filter to traditional ──────────────────
 analytic <- long_counts %>%


### PR DESCRIPTION
## Summary
- Remove rows mapped to the `Sex` subgroup after canonicalization to avoid combining male and female counts
- Apply the gender filter to pooled-rate and year-by-quartile scripts

## Testing
- `Rscript R/24_rates_pooled_by_year_blackquartile.R` *(failed: cannot download R packages via `renv` bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_68c441d1fe148331bd9c43c87c411e24