### PR TITLE
Use v6 race data for race/locale rates

### DIFF
--- a/Analysis/05a_rates_by_race_by_locale.R
+++ b/Analysis/05a_rates_by_race_by_locale.R
@@ -51,13 +51,9 @@ df_total <- v6 %>%
   mutate(rate=if_else(enroll>0, susp/enroll, NA_real_), race="All Students")
 
 # Race-specific
-##codex/edit-race-filter-for-hispanic/latino
-df_race <- v5 %>%
-###codex/import-and-use-allowed_races-constant
-  filter(subgroup %in% setdiff(ALLOWED_RACES, "All Students")) %>%
-
-  mutate(race=canon_race_label(subgroup)) %>%
-  filter(!is.na(race)) %>%
+df_race <- v6 %>%
+  mutate(race = canon_race_label(subgroup)) %>%
+  filter(race %in% setdiff(ALLOWED_RACES, "All Students")) %>%
   group_by(academic_year, locale_simple, race) %>%
   summarise(susp=sum(total_suspensions, na.rm=TRUE),
             enroll=sum(cumulative_enrollment, na.rm=TRUE), .groups="drop") %>%


### PR DESCRIPTION
## Summary
- Load race-specific suspension data from v6 instead of v5
- Canonicalize race labels before filtering on allowed races
- Remove leftover placeholder comments

## Testing
- `RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org Rscript Analysis/05a_rates_by_race_by_locale.R` *(fails: cannot access CRAN repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c446c4cfdc8331944b4719e435856d