### PR TITLE
Use canonical race labels for subgroup filters

### DIFF
--- a/Analysis/02c_claude_black_rates_by_quartiles.R
+++ b/Analysis/02c_claude_black_rates_by_quartiles.R
@@ -42,11 +42,11 @@ if (!"white_prop_q_label" %in% names(v6)) v6 <- v6 %>% mutate(white_prop_q_label
 
 # order x-axis by TA years that actually have enrollment
 year_levels <- v6 %>%
-  filter(category_type == "Race/Ethnicity", subgroup == "All Students", cumulative_enrollment > 0) %>%
+  filter(category_type == "Race/Ethnicity", canon_race_label(subgroup) == "All Students", cumulative_enrollment > 0) %>%
   distinct(academic_year) %>% arrange(academic_year) %>% pull(academic_year)
 
 # restrict to Black rows for all calculations
-black_students_data <- v6 %>% filter(subgroup == "Black/African American")
+black_students_data <- v6 %>% filter(canon_race_label(subgroup) == "Black/African American")
 
 # Reason columns: prefer *_count columns if present; otherwise derive from proportions
 has_count_cols <- all(c(

--- a/R/08_analysis_black_student_rates.R
+++ b/R/08_analysis_black_student_rates.R
@@ -23,7 +23,7 @@ v6 <- arrow::read_parquet(here::here("data-stage", "susp_v6_long.parquet")) %>%
 black_students_data <- v6 %>%
   filter(
     category_type == "Race/Ethnicity",
-    subgroup == "Black/African American"
+    canon_race_label(subgroup) == "Black/African American"
   )
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- Ensure subgroup filters use `canon_race_label()` and target the canonical "Black/African American" label in black-student analyses.
- Apply canonical race label filtering for "All Students" when determining available years.

## Testing
- `Rscript R/08_analysis_black_student_rates.R` *(fails: cannot download packages)*
- `Rscript Analysis/02c_claude_black_rates_by_quartiles.R` *(fails: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c446cc62e08331a635191052f7c04a