### PR TITLE
refactor: centralize school level helpers

### DIFF
--- a/Analysis/16_tail_concentration_analysis.R
+++ b/Analysis/16_tail_concentration_analysis.R
@@ -22,6 +22,9 @@ suppressPackageStartupMessages({
 
 try(here::i_am("Analysis/16_tail_concentration_analysis.R"), silent = TRUE)
 
+# Shared school-level helpers
+source(here::here("R", "utils_keys_filters.R"))
+
 ## -------------------------------------------------------------------------
 ## Configuration
 ## -------------------------------------------------------------------------

--- a/Analysis/17_tail_by_grade-school_concentration_analysis.R
+++ b/Analysis/17_tail_by_grade-school_concentration_analysis.R
@@ -13,6 +13,9 @@ suppressPackageStartupMessages({
 
 try(here::i_am("Analysis/17_tail_by_grade-school_concentration_analysis.R"), silent = TRUE)
 
+# Shared school-level helpers
+source(here::here("R", "utils_keys_filters.R"))
+
 ## -------------------------------------------------------------------------
 ## Configuration
 ## -------------------------------------------------------------------------

--- a/R/05_feature_school_level.R
+++ b/R/05_feature_school_level.R
@@ -10,6 +10,7 @@ suppressPackageStartupMessages({
   library(stringr)
   library(tibble)
 })
+# LEVEL_LABELS, span_label(), and is_alt() come from this utility
 source(here::here("R","utils_keys_filters.R"))
 message(">>> Running from project root: ", here::here())
 
@@ -40,23 +41,6 @@ extract_min_max_grade <- function(gs) {
 
 get_min_grade <- function(x) vapply(x, function(s) extract_min_max_grade(s)[1], numeric(1))
 get_max_grade <- function(x) vapply(x, function(s) extract_min_max_grade(s)[2], numeric(1))
-
-LEVEL_LABELS <- c("Elementary", "Middle", "High", "Other", "Alternative")
-
-span_label <- function(gmin, gmax) {
-  if (is.na(gmin) || is.na(gmax)) return("Other")
-  if (gmin <= 0 && gmax >= 12) return("Other")
-  if (gmax <= 5) return("Elementary")
-  if (gmin >= 6 && gmax <= 8) return("Middle")
-  if (gmax >= 9) return("High")
-  if (gmin <= 0 && gmax <= 8) return("Elementary")
-  "Other"
-}
-
-is_alt <- function(school_type) {
-  st <- tolower(ifelse(is.na(school_type), "", school_type))
-  str_detect(st, "juvenile court|community day|alternative|continuation")
-}
 
 # --- build features ---------------------------------------------------------
 v4 <- v3_in %>%

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -5,6 +5,30 @@ suppressPackageStartupMessages({
 
 SPECIAL_SCHOOL_CODES <- c("0000000", "0000001")
 
+# ---- School level classification ---------------------------------------------
+#' Canonical grade-span labels and helpers for school-level classification.
+#'
+#' `LEVEL_LABELS` enumerates the accepted school level categories.
+#' `span_label()` maps numeric grade bounds to those labels.
+#' `is_alt()` returns TRUE when a `school_type` string denotes an alternative program.
+#' Source this file to access these helpers in downstream scripts.
+LEVEL_LABELS <- c("Elementary", "Middle", "High", "Other", "Alternative")
+
+span_label <- function(gmin, gmax) {
+  if (is.na(gmin) || is.na(gmax)) return("Other")
+  if (gmin <= 0 && gmax >= 12) return("Other")
+  if (gmax <= 5) return("Elementary")
+  if (gmin >= 6 && gmax <= 8) return("Middle")
+  if (gmax >= 9) return("High")
+  if (gmin <= 0 && gmax <= 8) return("Elementary")
+  "Other"
+}
+
+is_alt <- function(school_type) {
+  st <- tolower(ifelse(is.na(school_type), "", school_type))
+  str_detect(st, "juvenile court|community day|alternative|continuation")
+}
+
 # ---- Locale reference ---------------------------------------------------------
 #' Canonical locale levels and color palette.
 #'


### PR DESCRIPTION
## Summary
- define shared `LEVEL_LABELS`, `span_label()`, and `is_alt()` in `utils_keys_filters.R`
- remove local copies in `05_feature_school_level.R`
- source school level helpers in feature script and tail concentration analyses

## Testing
- `Rscript -e "source('R/utils_keys_filters.R'); print(LEVEL_LABELS); print(span_label(0,5)); print(is_alt('Alternative Continuation'));"` *(failed: there is no package called 'dplyr')*
- `Rscript -e "install.packages('dplyr', repos='https://cloud.r-project.org')"` *(failed: unable to access package repository)*


------
https://chatgpt.com/codex/tasks/task_e_68c446f0388c8331ba9d175338404977