### PR TITLE
Restore 'All Students' demographic label

### DIFF
--- a/R/demographic_labels.R
+++ b/R/demographic_labels.R
@@ -6,7 +6,7 @@
 demographic_codebook <- tibble::tribble(
   ~subgroup_code, ~category_type,         ~subgroup,
   # Total
-  "TA",           "Total",                "Total",
+  "TA",           "Total",                "All Students",
   # Sex / Gender (canonical codes)
   "SF",           "Sex",                  "Female",
   "SM",           "Sex",                  "Male",
@@ -63,7 +63,7 @@ desc_to_canon <- function(desc) {
     grepl("reclassified\\s*fluent", d)                                           ~ "RFEP",
     grepl("initially\\s*fluent", d)                                              ~ "IFEP",
     grepl("\\benglish\\s*only|\\beo\\b", d)                                  ~ "EO",
-    grepl("\\benglish\\s*learner|\\bell\\b", d)                              ~ "EL",
+    grepl("\\benglish\\s*learner|\\bel(l)?\\b", d)                            ~ "EL",
     grepl("\\bfemale\\b|\\bsf\\b", d)                                       ~ "SF",
     grepl("\\bmale\\b|\\bsm\\b", d)                                         ~ "SM",
     grepl("non[- ]?binary|\\bsnb\\b", d)                                       ~ "SNB",
@@ -100,7 +100,7 @@ canon_label <- function(code) dplyr::recode(code,
   FY="Foster Youth", NF="Not Foster Youth",
   MG="Migrant", NM="Non-Migrant",
   HL="Homeless", NH="Not Homeless",
-  TA="Total",
+  TA="All Students",
   .default = NA_character_
 )
 

--- a/tests/testthat/test_demographic_labels.R
+++ b/tests/testthat/test_demographic_labels.R
@@ -14,7 +14,7 @@ test_that('code_alias_to_canon resolves known aliases', {
 test_that('canon_demo_label returns canonical labels', {
   inputs <- c('english learner','students with disabilities','Total')
   expect_equal(canon_demo_label(inputs),
-               c('English Learner','Students with Disabilities','Total'))
+               c('English Learner','Students with Disabilities','All Students'))
 })
 
 test_that('canonicalize_demo adds canonical fields', {


### PR DESCRIPTION
## Summary
- Reinstate "All Students" as the canonical label for total demographic code TA.
- Broaden descriptor canonicalization so "EL" and "ELL" map to English Learner.
- Update tests to expect the new label.

## Testing
- `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE R -q -e "library(rlang); testthat::test_dir('tests/testthat')"`
- `rg -n "All Students" Analysis R`


------
https://chatgpt.com/codex/tasks/task_e_68c4737b6538833191f457f5dbb13008