### PR TITLE
Handle optional subgroup filter in year_levels

### DIFF
--- a/Analysis/15_merge_demographic_categories.R
+++ b/Analysis/15_merge_demographic_categories.R
@@ -119,8 +119,13 @@ cat("Capped", sum(demo_data$rate_flag, na.rm = TRUE), "impossible suspension cou
 # -------- Create canonical school attributes --------------------------------
 # Year ordering (prefer TA in race_data if present)
 year_levels <- race_data %>%
-  filter(if ("subgroup" %in% names(.)) category_type == "Race/Ethnicity", subgroup == "All Students" else TRUE) %>%
-  distinct(academic_year) %>% arrange(academic_year) %>% pull()
+  { if ("subgroup" %in% names(.))
+      filter(., category_type == "Race/Ethnicity", subgroup == "All Students")
+    else .
+  } %>%
+  distinct(academic_year) %>%
+  arrange(academic_year) %>%
+  pull()
 
 if (!length(year_levels)) {
   year_levels <- demo_data %>% distinct(academic_year) %>% arrange(academic_year) %>% pull()


### PR DESCRIPTION
## Summary
- Use brace expression to only filter race data when `subgroup` column is present

## Testing
- `Rscript -e 'source("Analysis/15_merge_demographic_categories.R"); print(year_levels)'` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c58c4344048331941d99f488487b43