### PR TITLE
Guard build_keys when CDS components missing

### DIFF
--- a/Analysis/15a_emit_nonintersectional_exports.R
+++ b/Analysis/15a_emit_nonintersectional_exports.R
@@ -80,8 +80,26 @@ if (is.na(RACE_LONG_PATH)) {
 #######
 
 race_long <- arrow::read_parquet(RACE_LONG_PATH) %>%
-  clean_names() %>%
-  build_keys() %>%
+  clean_names()
+
+if (!all(c("county_code", "district_code", "school_code") %in% names(race_long))) {
+  if ("cds_school" %in% names(race_long)) {
+    race_long <- race_long %>%
+      mutate(
+        county_code   = substr(cds_school, 1, 2),
+        district_code = substr(cds_school, 3, 7),
+        school_code   = substr(cds_school, 8, 14)
+      )
+  }
+}
+
+if (all(c("county_code", "district_code", "school_code") %in% names(race_long))) {
+  race_long <- race_long %>% build_keys()
+} else {
+  warning("[15a] Missing county/district/school codes; skipping build_keys().")
+}
+
+race_long <- race_long %>%
   mutate(year = suppressWarnings(as.integer(substr(as.character(academic_year), 1, 4))))
 
 present_reason_cols <- intersect(REASON_COLS, names(race_long))
@@ -99,8 +117,26 @@ if (!file.exists(OTH_PARQUET)) {
   stop("[15a] Missing file: data-stage/oth_long.parquet. Run analysis/01b_ingest_demographics.R first.")
 }
 demo_data <- arrow::read_parquet(OTH_PARQUET) %>%
-  clean_names() %>%
-  build_keys() %>%
+  clean_names()
+
+if (!all(c("county_code", "district_code", "school_code") %in% names(demo_data))) {
+  if ("cds_school" %in% names(demo_data)) {
+    demo_data <- demo_data %>%
+      mutate(
+        county_code   = substr(cds_school, 1, 2),
+        district_code = substr(cds_school, 3, 7),
+        school_code   = substr(cds_school, 8, 14)
+      )
+  }
+}
+
+if (all(c("county_code", "district_code", "school_code") %in% names(demo_data))) {
+  demo_data <- demo_data %>% build_keys()
+} else {
+  warning("[15a] Missing county/district/school codes; skipping build_keys().")
+}
+
+demo_data <- demo_data %>%
   mutate(year = suppressWarnings(as.integer(substr(as.character(academic_year), 1, 4)))) %>%
   canonicalize_undup()
 
@@ -120,8 +156,26 @@ stopifnot(file.exists(v6_path))
 
 # 1) Read and keep aggregate_level if present
 v6_keys_raw <- arrow::read_parquet(v6_path) %>%
-  clean_names() %>%
-  build_keys() %>%
+  clean_names()
+
+if (!all(c("county_code", "district_code", "school_code") %in% names(v6_keys_raw))) {
+  if ("cds_school" %in% names(v6_keys_raw)) {
+    v6_keys_raw <- v6_keys_raw %>%
+      mutate(
+        county_code   = substr(cds_school, 1, 2),
+        district_code = substr(cds_school, 3, 7),
+        school_code   = substr(cds_school, 8, 14)
+      )
+  }
+}
+
+if (all(c("county_code", "district_code", "school_code") %in% names(v6_keys_raw))) {
+  v6_keys_raw <- v6_keys_raw %>% build_keys()
+} else {
+  warning("[15a] Missing county/district/school codes; skipping build_keys().")
+}
+
+v6_keys_raw <- v6_keys_raw %>%
   select(
     academic_year, county_code, district_code, school_code,
     county_name, district_name, school_name,


### PR DESCRIPTION
## Summary
- Ensure race_long, demo_data, and v6_keys_raw verify presence of county, district, and school codes before invoking `build_keys()`
- Derive codes from `cds_school` when available and warn if codes are absent

## Testing
- `Rscript Analysis/15a_emit_nonintersectional_exports.R` *(fails: unable to download renv packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c58c4b49308331bd465ad9d1bae5f2