### PR TITLE
Validate key codes before building

### DIFF
--- a/Analysis/15a_emit_nonintersectional_exports.R
+++ b/Analysis/15a_emit_nonintersectional_exports.R
@@ -63,25 +63,6 @@ canonicalize_undup <- function(df) {
              suppressWarnings(as.numeric(unduplicated_count_of_students_suspended_total)))
 }
 
-ensure_keys <- function(df) {
-  if (!all(c("county_code", "district_code", "school_code") %in% names(df))) {
-    if ("cds_school" %in% names(df)) {
-      df <- df %>%
-        mutate(
-          county_code   = substr(cds_school, 1, 2),
-          district_code = substr(cds_school, 3, 7),
-          school_code   = substr(cds_school, 8, 14)
-        )
-    }
-  }
-  if (all(c("county_code", "district_code", "school_code") %in% names(df))) {
-    df %>% build_keys()
-  } else {
-    warning("[15a] Missing county/district/school codes; skipping build_keys().")
-    df
-  }
-}
-
 # -------------------------------------------------------------------
 # 1) Read race-long (has reason columns)
 # -------------------------------------------------------------------
@@ -100,7 +81,7 @@ if (is.na(RACE_LONG_PATH)) {
 
 race_long <- arrow::read_parquet(RACE_LONG_PATH) %>%
   clean_names() %>%
-  ensure_keys()
+  build_keys()
 
 race_long <- race_long %>%
   mutate(year = suppressWarnings(as.integer(substr(as.character(academic_year), 1, 4))))
@@ -121,7 +102,7 @@ if (!file.exists(OTH_PARQUET)) {
 }
 demo_data <- arrow::read_parquet(OTH_PARQUET) %>%
   clean_names() %>%
-  ensure_keys() %>%
+  build_keys() %>%
   mutate(year = suppressWarnings(as.integer(substr(as.character(academic_year), 1, 4)))) %>%
   canonicalize_undup()
 
@@ -142,7 +123,7 @@ stopifnot(file.exists(v6_path))
 # 1) Read and keep aggregate_level if present
 v6_keys_raw <- arrow::read_parquet(v6_path) %>%
   clean_names() %>%
-  ensure_keys() %>%
+  build_keys() %>%
   select(
     academic_year, county_code, district_code, school_code,
     county_name, district_name, school_name,


### PR DESCRIPTION
## Summary
- Add `ensure_keys()` to guarantee county, district, and school codes exist and split from `cds_school` when available
- Call `ensure_keys()` inside `build_keys()` and error if codes are missing, prompting rebuild of `susp_v6_long.parquet`
- Use shared `build_keys()` in non‑intersectional export script

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: cannot download renv packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c597ac092c833181c944a7b51f9175