### PR TITLE
Include IDs in oth_long

### DIFF
--- a/R/22_build_v6_features.R
+++ b/R/22_build_v6_features.R
@@ -110,7 +110,10 @@ if (REBUILD_V6 || !file.exists(V6_FEAT_PARQ)) {
   # OTH → long metrics (category, subgroup)
   oth_long <- oth %>%
     transmute(
+      county_code,
+      district_code,
       school_code,
+      cds_school,
       academic_year,
       category = category_type,
       subgroup,


### PR DESCRIPTION
## Summary
- Ensure `oth_long` retains district identifiers (`county_code`, `district_code`, `school_code`, and `cds_school`).

## Testing
- `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE Rscript R/22_build_v6_features.R` *(fails: there is no package called 'arrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c597a5417c8331b1e7d3491b9eb315