### PR TITLE
Ensure v6 features include school names and add export checks

### DIFF
--- a/Analysis/15a_emit_nonintersectional_exports.R
+++ b/Analysis/15a_emit_nonintersectional_exports.R
@@ -233,7 +233,14 @@ all_students <- race_long %>%
   inner_join(
     v6_schools_only %>% select(academic_year, county_code, district_code, school_code),
     by = c("academic_year","county_code","district_code","school_code")
-  ) %>%
+  )
+
+missing_names <- setdiff(c("county_name","district_name","school_name"), names(all_students))
+if (length(missing_names)) {
+  stop("[15a] Missing expected name columns: ", paste(missing_names, collapse = ", "))
+}
+
+all_students <- all_students %>%
   select_existing(c(
     "year","academic_year",
     "county_code","district_code","school_code",


### PR DESCRIPTION
## Summary
- Carry county, district, and school names through v6 feature build and backfill missing names from v5 when needed
- Explicitly verify expected name columns before selecting fields in non-intersectional export script

## Testing
- `R --vanilla -f R/22_build_v6_features.R` *(fails: there is no package called 'dplyr')*
- `R --vanilla -f Analysis/15a_emit_nonintersectional_exports.R` *(fails: there is no package called 'arrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c5a38ff654833191649e7c180ad25f