### PR TITLE
Validate category_type presence in race data

### DIFF
--- a/Analysis/15_merge_demographic_categories.R
+++ b/Analysis/15_merge_demographic_categories.R
@@ -46,8 +46,12 @@ norm <- function(x) {
 
 # -------- Load and validate data ---------------------------------------------
 cat("\n=== Loading race data ===\n")
-race_data <- arrow::read_parquet(RACE_DATA_PATH) %>% 
+race_data <- arrow::read_parquet(RACE_DATA_PATH) %>%
   janitor::clean_names()
+
+if (!"category_type" %in% names(race_data)) {
+  stop("`susp_v6_long.parquet` missing `category_type`; rebuild v6 long parquet.")
+}
 
 # Create academic_year if needed
 if (!"academic_year" %in% names(race_data) && "year" %in% names(race_data)) {


### PR DESCRIPTION
## Summary
- Fail early if susp_v6_long.parquet lacks `category_type`

## Testing
- `RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org Rscript -e "testthat::test_dir('tests')"` *(fails: cannot access repository index)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a390dedc8331941d224b938b5c9f