### PR TITLE
Ensure race_long has subgroup descriptions

### DIFF
--- a/Analysis/15a_emit_nonintersectional_exports.R
+++ b/Analysis/15a_emit_nonintersectional_exports.R
@@ -83,6 +83,9 @@ race_long <- arrow::read_parquet(RACE_LONG_PATH) %>%
   clean_names() %>%
   build_keys()
 
+if (!"subgroup_description" %in% names(race_long))
+  race_long <- mutate(race_long, subgroup_description = subgroup)
+
 race_long <- race_long %>%
   mutate(year = suppressWarnings(as.integer(substr(as.character(academic_year), 1, 4))))
 


### PR DESCRIPTION
## Summary
- Ensure `race_long` has `subgroup_description` column by populating it from `subgroup` when missing
- Keep existing subgroup label handling in non-intersectional exports

## Testing
- `Rscript Analysis/15a_emit_nonintersectional_exports.R` *(fails: unable to download renv packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d7e8a1a48331af8ce15f0992b29c