### PR TITLE
Use academic_year for traditional year key

### DIFF
--- a/Analysis/18_comprehensive_suspension_rates_analysis.R
+++ b/Analysis/18_comprehensive_suspension_rates_analysis.R
@@ -117,9 +117,10 @@ v6_traditional <- v6_features %>%
   clean_names() %>%
   transmute(
     school_code = as.character(school_code),
-    year = as.character(year),
+    year = as.character(academic_year),
     is_traditional = !is.na(is_traditional) & is_traditional
   ) %>%
+  select(school_code, year, is_traditional) %>%
   distinct()
 
 # Step 3: Join and finalize


### PR DESCRIPTION
## Summary
- Fix v6_traditional year to derive from `academic_year`
- Ensure `v6_traditional` only contains `school_code`, `year`, `is_traditional`

## Testing
- ⚠️ `Rscript Analysis/18_comprehensive_suspension_rates_analysis.R` *(failed: cannot download renv packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c5df20d2c88331970ea90c62202016