### PR TITLE
Summarize all students enrollment before computing Black proportions

### DIFF
--- a/Analysis/19_statewide_rates_and_quartiles.R
+++ b/Analysis/19_statewide_rates_and_quartiles.R
@@ -108,11 +108,12 @@ write_parquet(by_enrollment, here("data-stage", "quartile_rates_by_enrollment.pa
 # Compute proportion of Black enrollment out of school total and derive quartiles
 all_enroll <- v6 %>%
   filter(subgroup == "All Students") %>%
-  select(cds_school, academic_year, total_enrollment_all = cumulative_enrollment)
+  group_by(cds_school, academic_year) %>%
+  summarise(total_enrollment_all = sum(cumulative_enrollment), .groups = "drop")
 
 black_prop <- v6 %>%
   filter(subgroup == "Black/African American") %>%
-  left_join(all_enroll, by = c("cds_school", "academic_year")) %>%
+  left_join(all_enroll, by = c("cds_school", "academic_year"), relationship = "one-to-one") %>%
   mutate(black_prop = if_else(total_enrollment_all > 0, cumulative_enrollment / total_enrollment_all, NA_real_))
 
 by_black_prop <- black_prop %>%


### PR DESCRIPTION
## Summary
- Deduplicate `all_enroll` totals by school and year before computing Black enrollment shares.
- Enforce a one-to-one join between Black subgroup records and total enrollment for safer proportion calculations.

## Testing
- `R --vanilla -q -e 'library(testthat); testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_68c5e1d07f588331a805e7641b204cbc