### PR TITLE
Summarise school enrollment before quartile joins

### DIFF
--- a/Analysis/19_statewide_rates_and_quartiles.R
+++ b/Analysis/19_statewide_rates_and_quartiles.R
@@ -73,14 +73,21 @@ write_parquet(
 # Quartiles by total school enrollment (All Students baseline)
 school_enroll <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
-  select(cds_school, academic_year, total_enrollment_all = cumulative_enrollment) %>%
+  group_by(cds_school, academic_year) %>%
+  summarise(
+    total_enrollment_all = sum(cumulative_enrollment, na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
   group_by(academic_year) %>%
   mutate(enrollment_q = ntile(total_enrollment_all, 4)) %>%
   ungroup()
 
 v6_enroll_q <- v6 %>%
-  left_join(school_enroll %>% select(cds_school, academic_year, enrollment_q),
-    by = c("cds_school", "academic_year"))
+  left_join(
+    school_enroll %>% select(cds_school, academic_year, enrollment_q),
+    by = c("cds_school", "academic_year"),
+    relationship = "one-to-one"
+  )
 
 v6_enroll_q_all <- bind_rows(
   v6_enroll_q,


### PR DESCRIPTION
## Summary
- Ensure `school_enroll` collapses to one row per school-year before computing quartiles
- Join enrollment quartiles with `left_join(..., relationship = "one-to-one")`

## Testing
- `Rscript --vanilla Analysis/19_statewide_rates_and_quartiles.R` *(fails: there is no package called 'arrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c5e1cf5084833192e0d40d7743326a