### PR TITLE
Ensure unique school-year enrollment before quartile assignment

### DIFF
--- a/Analysis/19_statewide_rates_and_quartiles.R
+++ b/Analysis/19_statewide_rates_and_quartiles.R
@@ -71,11 +71,12 @@ write_parquet(
 # ---- Quartile helpers --------------------------------------------------------
 ##codex/create-statewide-data-frame-analysis-ke1b6u
 # Quartiles by total school enrollment (All Students baseline)
+# Ensure one row per school-year before assigning quartiles
 school_enroll <- v6 %>%
   filter(category_type == "Race/Ethnicity", subgroup == "All Students") %>%
   group_by(cds_school, academic_year) %>%
   summarise(
-    total_enrollment_all = sum(cumulative_enrollment, na.rm = TRUE),
+    total_enrollment_all = first(cumulative_enrollment),
     .groups = "drop"
   ) %>%
   group_by(academic_year) %>%


### PR DESCRIPTION
## Summary
- Avoid duplicate school-year rows when computing enrollment quartiles by summarising enrollment per school/year
- Continue joining enrollment quartiles with a one-to-one relationship to catch duplicates

## Testing
- `Rscript --no-init-file Analysis/19_statewide_rates_and_quartiles.R` *(fails: there is no package called 'here')*
- `Rscript --no-init-file -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_68c5e5921ce88331a4e7c19a2140944d