### PR TITLE
Allow many-to-one join for enrollment quartiles

### DIFF
--- a/Analysis/19_statewide_rates_and_quartiles.R
+++ b/Analysis/19_statewide_rates_and_quartiles.R
@@ -115,7 +115,7 @@ v6_enroll_q <- v6 %>%
   left_join(
     school_enroll %>% select(cds_school, academic_year, enrollment_q),
     by = c("cds_school", "academic_year"),
-    relationship = "one-to-one"
+    relationship = "many-to-one"
   )
 
 v6_enroll_q_all <- bind_rows(


### PR DESCRIPTION
## Summary
- allow multiple subgroup rows to match a single school enrollment record in quartile join

## Testing
- `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: could not find function "%||%" in demographic_labels.R)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ed0945d8833191114ace91a47d17