### PR TITLE
Refine Black enrollment proportion calculation

### DIFF
--- a/Analysis/19_statewide_rates_and_quartiles.R
+++ b/Analysis/19_statewide_rates_and_quartiles.R
@@ -182,19 +182,25 @@ all_enroll <- v6 %>%
   )
 
 black_prop <- v6 %>%
-  filter(subgroup == "Black/African American") %>%
-  left_join(
-    all_enroll,
-    by = c("cds_school", "academic_year"),
-    relationship = "one-to-one"
+  filter(
+    category_type == "Race/Ethnicity",
+    subgroup == "Black/African American"
   ) %>%
+  group_by(cds_school, academic_year) %>%
+  summarise(
+    total_suspensions = sum(total_suspensions, na.rm = TRUE),
+    black_enrollment   = sum(cumulative_enrollment, na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
+  left_join(all_enroll, by = c("cds_school", "academic_year")) %>%
   mutate(
     black_prop = if_else(
       total_enrollment_all > 0,
-      cumulative_enrollment / total_enrollment_all,
+      black_enrollment / total_enrollment_all,
       NA_real_
     )
-  )
+  ) %>%
+  rename(cumulative_enrollment = black_enrollment)
 
 by_black_prop <- black_prop %>%
   group_by(academic_year) %>%


### PR DESCRIPTION
## Summary
- ensure Black enrollment is summarized per school-year before computing proportion of Black students
- join summarized enrollment to school totals and derive Black enrollment share

## Testing
- `Rscript --vanilla -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_68c5f5ad5fd88331bf2e53f43b362d39