### PR TITLE
Use first enrollment value for all student totals

### DIFF
--- a/Analysis/19_statewide_rates_and_quartiles.R
+++ b/Analysis/19_statewide_rates_and_quartiles.R
@@ -177,7 +177,7 @@ all_enroll <- v6 %>%
   filter(subgroup == "All Students") %>%
   group_by(cds_school, academic_year) %>%
   summarise(
-    total_enrollment_all = sum(cumulative_enrollment, na.rm = TRUE),
+    total_enrollment_all = first(cumulative_enrollment),
     .groups = "drop"
   )
 


### PR DESCRIPTION
## Summary
- Avoid double-counting by using `first(cumulative_enrollment)` when collecting All Students totals

## Testing
- `R --vanilla -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fd9cfcc48331bc0d94416b35fd12