### PR TITLE
Centralize level and locale constants across analysis scripts

### DIFF
--- a/Analysis/06_rates_by_race_traditional_vs_other.R
+++ b/Analysis/06_rates_by_race_traditional_vs_other.R
@@ -59,8 +59,8 @@ if (!length(year_levels)) stop("No TA rows to establish year order.")
 v6 <- v6 %>%
   mutate(
     school_group = dplyr::case_when(
-      school_level %in% c("Elementary","Middle","High") ~ "Traditional",
-      TRUE                                                   ~ "All other"
+      school_level %in% setdiff(LEVEL_LABELS, c("Other", "Alternative")) ~ "Traditional",
+      TRUE                                                                ~ "All other"
     )
   )
 

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -52,8 +52,8 @@ if (!length(year_levels)) stop("No TA rows to establish academic year order.")
 v6 <- v6 %>%
   mutate(
     school_group = dplyr::case_when(
-      school_level %in% c("Elementary","Middle","High") ~ "Traditional",
-      TRUE                                                  ~ "All other"
+      school_level %in% setdiff(LEVEL_LABELS, c("Other", "Alternative")) ~ "Traditional",
+      TRUE                                                               ~ "All other"
     )
   )
 

--- a/Analysis/17_tail_by_grade-school_concentration_analysis.R
+++ b/Analysis/17_tail_by_grade-school_concentration_analysis.R
@@ -50,6 +50,9 @@ TOP_PCT <- c(0.05, 0.10, 0.20)
 RATE_PCTS <- c(0.90, 0.95)
 RATE_PER <- 100
 
+# canonical grade levels
+GRADE_LEVELS <- setdiff(LEVEL_LABELS, c("Other", "Alternative"))
+
 ## -------------------------------------------------------------------------
 ## Helper Functions
 ## -------------------------------------------------------------------------
@@ -224,7 +227,7 @@ generate_comparison_tables <- function(df, output_dir) {
   # Compare traditional vs non-traditional by grade level
   comparison_by_grade <- df %>%
     filter(!is.na(level), !is.na(setting), 
-           level %in% c("Elementary", "Middle", "High"),
+           level %in% GRADE_LEVELS,
            setting %in% c("Traditional", "Non-traditional")) %>%
     group_by(year_num, level, setting) %>%
     summarise(

--- a/Analysis/18_comprehensive_suspension_rates_analysis.R
+++ b/Analysis/18_comprehensive_suspension_rates_analysis.R
@@ -136,7 +136,7 @@ analytic_data <- v6_complete %>%
     black_q = order_quartile(black_q),
     white_q = order_quartile(white_q),
     setting = factor(setting, levels = c("Traditional", "Non-traditional")),
-    grade_level = factor(grade_level, levels = c("Elementary", "Middle", "High", "Other", "Alternative"))
+    grade_level = factor(grade_level, levels = LEVEL_LABELS)
   )
 
 # NOW add the diagnostic code:
@@ -333,7 +333,7 @@ create_grade_level_plot <- function() {
     filter(
       race_ethnicity == "Black/African American",
       setting == "Traditional",
-      grade_level %in% c("Elementary", "Middle", "High", "Other")
+      grade_level %in% setdiff(LEVEL_LABELS, "Alternative")
     ) %>%
     calc_summary_stats(year, grade_level, black_q)
   

--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -141,8 +141,10 @@ ggsave(file.path(out_dir, "20_overall_reason_rates.png"), p_overall_reason,
        width = 10, height = 6, dpi = 300)
 
 # --- 4) By grade level -------------------------------------------------------
-grade_levels <- c("Elementary", "Middle", "High")
-by_grade <- v6 %>% filter(school_level %in% grade_levels)
+grade_levels <- setdiff(LEVEL_LABELS, c("Other", "Alternative"))
+by_grade <- v6 %>%
+  filter(school_level %in% grade_levels) %>%
+  mutate(school_level = factor(school_level, levels = grade_levels))
 
 grade_rates <- summarise_reason_rates(by_grade, c("academic_year", "school_level"))
 save_table(grade_rates, "20_grade_reason_rates.csv")
@@ -161,8 +163,10 @@ ggsave(file.path(out_dir, "20_grade_reason_rates.png"), p_grade_reason,
        width = 12, height = 8, dpi = 300)
 
 # --- 5) By locale ------------------------------------------------------------
-loc_levels <- c("City", "Suburban", "Town", "Rural")
-by_locale <- v6 %>% filter(locale_simple %in% loc_levels)
+loc_levels <- setdiff(locale_levels, "Unknown")
+by_locale <- v6 %>%
+  filter(locale_simple %in% loc_levels) %>%
+  mutate(locale_simple = factor(locale_simple, levels = loc_levels))
 
 locale_rates <- summarise_reason_rates(by_locale, c("academic_year", "locale_simple"))
 save_table(locale_rates, "20_locale_reason_rates.csv")


### PR DESCRIPTION
## Summary
- Reference canonical `LEVEL_LABELS` and `locale_levels` constants across analysis scripts.
- Ensure grade and locale factors use consistent level ordering.

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat", reporter = "summary")'` *(fails: unable to download required packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c6036c841c8331b00f465099316abf