### PR TITLE
Add consistent grade level palette

### DIFF
--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -149,7 +149,8 @@ save_table(grade_rates, "20_grade_reason_rates.csv")
 
 p_grade_total <- plot_total_rate(distinct(grade_rates, academic_year, school_level, total_rate),
                                  "Suspension Rate by Grade Level",
-                                 color_col = "school_level")
+                                 color_col = "school_level",
+                                 palette = pal_level[grade_levels])
 
 ggsave(file.path(out_dir, "20_grade_total_rate.png"), p_grade_total,
        width = 10, height = 6, dpi = 300)

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -14,6 +14,15 @@ SPECIAL_SCHOOL_CODES <- c("0000000", "0000001")
 #' Source this file to access these helpers in downstream scripts.
 LEVEL_LABELS <- c("Elementary", "Middle", "High", "Other", "Alternative")
 
+#' Consistent color palette for grade levels
+pal_level <- c(
+  Elementary = "#1b9e77",
+  Middle     = "#d95f02",
+  High       = "#7570b3",
+  Other      = "#e7298a",
+  Alternative= "#66a61e"
+)
+
 span_label <- function(gmin, gmax) {
   if (is.na(gmin) || is.na(gmax)) return("Other")
   if (gmin <= 0 && gmax >= 12) return("Other")


### PR DESCRIPTION
## Summary
- add `pal_level` for standard grade-level colors
- apply grade-level palette in suspension reason trend plots

## Testing
- `Rscript -e "devtools::test()"` *(fails: cannot access package repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c6037b9af08331bb6bf8d0f03d3129