### PR TITLE
Validate suspension reasons against known labels

### DIFF
--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -85,6 +85,19 @@ pal_reason <- setNames(
 # helper to append readable reason labels
 add_reason_label <- function(df, reason_col = "reason") {
   reason_sym <- rlang::sym(reason_col)
+
+  # identify unexpected reason codes and stop early
+  unmatched <- setdiff(unique(df[[reason_col]]), reason_labels$reason)
+  unmatched <- unmatched[!is.na(unmatched)]
+  if (length(unmatched) > 0) {
+    stop(
+      sprintf(
+        "Unexpected reason codes: %s",
+        paste(unmatched, collapse = ", ")
+      )
+    )
+  }
+
   dplyr::left_join(df, reason_labels, by = setNames("reason", reason_col)) %>%
     dplyr::mutate(
       !!reason_sym := factor(!!reason_sym, levels = reason_labels$reason),


### PR DESCRIPTION
## Summary
- stop if suspension reason codes aren't recognized

## Testing
- `Rscript --vanilla -e "source('R/utils_keys_filters.R'); df <- data.frame(reason=c('violent_injury','unknown')); add_reason_label(df)"` *(fails: there is no package called ‘dplyr’)*
- `Rscript --vanilla -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68c612a14ce08331809e69c52bf0eef1