### PR TITLE
Ensure consistent color mapping for suspension reasons

### DIFF
--- a/R/07_explore_trends.R
+++ b/R/07_explore_trends.R
@@ -126,7 +126,8 @@ p1b <- ggplot(reason_rate_by_black_quartile,
                 label = percent(total_rate, accuracy = 0.1)),
             vjust = -0.5, fontface = "bold", inherit.aes = FALSE, na.rm = TRUE) +
   facet_wrap(~ black_prop_q_label, ncol = 2) +
-  scale_fill_manual(values = pal_reason, name = "Reason for Suspension") +
+  scale_fill_manual(values = pal_reason, name = "Reason for Suspension",
+                    breaks = names(pal_reason), drop = FALSE) +
   scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
   labs(
     title = "Composition of Black Student Suspensions by School's Black Enrollment",
@@ -216,7 +217,8 @@ p2b <- ggplot(reason_rate_by_white_quartile,
     vjust = -0.5, fontface = "bold", inherit.aes = FALSE, na.rm = TRUE
   ) +
   facet_wrap(~ white_prop_q_label, ncol = 2) +
-  scale_fill_manual(values = pal_reason, name = "Reason for Suspension") +
+  scale_fill_manual(values = pal_reason, name = "Reason for Suspension",
+                    breaks = names(pal_reason), drop = FALSE) +
   scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
   labs(
     title = "Composition of Black Student Suspensions by School's White Enrollment",

--- a/R/08_analysis_black_student_rates.R
+++ b/R/08_analysis_black_student_rates.R
@@ -103,7 +103,7 @@ p2_reasons_by_black <- ggplot(reason_rate_by_black_quartile, aes(x = academic_ye
             aes(x = academic_year, y = total_rate, label = percent(total_rate, accuracy = 0.1)),
             vjust = -0.5, fontface = "bold", inherit.aes = FALSE) +
   facet_wrap(~ black_prop_q_label, ncol = 2) +
-  scale_fill_manual(values = pal_reason, breaks = names(pal_reason)) +
+  scale_fill_manual(values = pal_reason, breaks = names(pal_reason), drop = FALSE) +
   scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
   labs(
     title = "Composition of Black Student Suspensions by School's Black Enrollment",
@@ -184,7 +184,7 @@ p4_reasons_by_white <- ggplot(reason_rate_by_white_quartile, aes(x = academic_ye
             aes(x = academic_year, y = total_rate, label = percent(total_rate, accuracy = 0.1)),
             vjust = -0.5, fontface = "bold", inherit.aes = FALSE) +
   facet_wrap(~ white_prop_q_label, ncol = 2) +
-  scale_fill_manual(values = pal_reason, breaks = names(pal_reason)) +
+  scale_fill_manual(values = pal_reason, breaks = names(pal_reason), drop = FALSE) +
   scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
   labs(
     title = "Composition of Black Student Suspensions by School's White Enrollment",


### PR DESCRIPTION
## Summary
- specify breaks and prevent dropping levels in pal_reason fill scales

## Testing
- `Rscript --vanilla R/07_explore_trends.R` *(fails: there is no package called 'arrow')*
- `Rscript --vanilla R/08_analysis_black_student_rates.R` *(fails: there is no package called 'arrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c612ad18888331a86cc9c03e9d946c