### PR TITLE
fix: align suspension reason labels

### DIFF
--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -141,6 +141,9 @@ plot_reason_area <- function(df, facet_col = NULL, title_txt) {
 
 # --- 3) Overall trends -------------------------------------------------------
 overall_rates <- summarise_reason_rates(v6, "academic_year")
+print(unique(overall_rates$reason_lab))
+print(names(pal_reason))
+print(setdiff(unique(overall_rates$reason_lab), names(pal_reason)))
 save_table(overall_rates, "20_overall_reason_rates.csv")
 
 p_overall_total <- plot_total_rate(distinct(overall_rates, academic_year, total_rate),

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -70,7 +70,7 @@ reason_labels <- dplyr::tibble(
     "Violent (Injury)",
     "Violent (No Injury)",
     "Weapons",
-    "Illicit Drug",
+    "Illicit Drugs",
     "Willful Defiance",
     "Other"
   )


### PR DESCRIPTION
## Summary
- standardize suspension reason labels and palette
- log reason/palette mismatches during overall-rate calculation

## Testing
- `RENV_CONFIG_AUTO_ACTIVATE=FALSE Rscript --vanilla Analysis/20_suspension_reason_trends_by_level_and_locale.R` *(fails: there is no package called 'arrow')*
- `RENV_CONFIG_AUTO_ACTIVATE=FALSE Rscript --vanilla -e 'testthat::test_dir("tests/testthat")'` *(fails: could not find function "%||%")*

------
https://chatgpt.com/codex/tasks/task_e_68c6129d1e2483318abcded4ffe7c68c