### PR TITLE
Add tests for palette and reason labeling helpers

### DIFF
--- a/tests/testthat/test_utils_keys_filters.R
+++ b/tests/testthat/test_utils_keys_filters.R
@@ -1,0 +1,14 @@
+source(normalizePath(file.path('..','..','R','utils_keys_filters.R')))
+library(testthat)
+
+test_that('palettes have names matching their levels', {
+  expect_equal(names(pal_level), LEVEL_LABELS)
+  expect_equal(names(pal_locale), locale_levels)
+  expect_equal(names(pal_reason), reason_labels$reason_lab)
+})
+
+test_that('add_reason_label returns no NA values for known keys', {
+  df <- data.frame(reason = reason_labels$reason)
+  out <- add_reason_label(df)
+  expect_false(any(is.na(out$reason_lab)))
+})


### PR DESCRIPTION
## Summary
- test that pal_level, pal_locale, pal_reason names align with their level vectors
- test add_reason_label to ensure it produces no missing labels

## Testing
- `R --vanilla -q -e 'devtools::test()'` *(fails: Could not find package root)*
- `R --vanilla -q -e 'testthat::test_dir("tests/testthat")'` *(fails: existing demographic label tests could not find %||% function)*

------
https://chatgpt.com/codex/tasks/task_e_68c612b3762c8331b8508d3b7eadc9fc