### PR TITLE
Add test for pal_reason scale_fill_manual

### DIFF
--- a/tests/testthat/test_utils_keys_filters.R
+++ b/tests/testthat/test_utils_keys_filters.R
@@ -12,3 +12,16 @@ test_that('add_reason_label returns no NA values for known keys', {
   out <- add_reason_label(df)
   expect_false(any(is.na(out$reason_lab)))
 })
+
+test_that('scale_fill_manual uses pal_reason without warning', {
+  df <- tibble::tibble(
+    reason_lab = factor(names(pal_reason), levels = names(pal_reason)),
+    n = seq_along(pal_reason)
+  )
+  p <- ggplot2::ggplot(df, ggplot2::aes(reason_lab, n, fill = reason_lab)) +
+    ggplot2::geom_col() +
+    ggplot2::scale_fill_manual(values = pal_reason,
+                               breaks = names(pal_reason),
+                               drop = FALSE)
+  expect_no_warning(ggplot2::ggplot_build(p))
+})


### PR DESCRIPTION
## Summary
- add regression test ensuring pal_reason works with `scale_fill_manual`

## Testing
- `RENV_CONFIG_REPOS_OVERRIDE=https://cran.r-project.org R -q -e "devtools::test()"` *(fails: unable to access CRAN repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ec3726c83318f3a38097957bcbf