### PR TITLE
Ensure consistent reason color mapping

### DIFF
--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -140,7 +140,8 @@ plot_reason_area <- function(df, facet_col = NULL, title_txt) {
 }
 
 # --- 3) Overall trends -------------------------------------------------------
-overall_rates <- summarise_reason_rates(v6, "academic_year")
+overall_rates <- summarise_reason_rates(v6, "academic_year") %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 print(unique(overall_rates$reason_lab))
 print(names(pal_reason))
 print(setdiff(unique(overall_rates$reason_lab), names(pal_reason)))
@@ -164,7 +165,8 @@ by_grade <- v6 %>%
   filter(school_level %in% grade_levels) %>%
   mutate(school_level = factor(school_level, levels = grade_levels))
 
-grade_rates <- summarise_reason_rates(by_grade, c("academic_year", "school_level"))
+grade_rates <- summarise_reason_rates(by_grade, c("academic_year", "school_level")) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 save_table(grade_rates, "20_grade_reason_rates.csv")
 
 p_grade_total <- plot_total_rate(distinct(grade_rates, academic_year, school_level, total_rate),
@@ -187,7 +189,8 @@ by_locale <- v6 %>%
   filter(locale_simple %in% loc_levels) %>%
   mutate(locale_simple = factor(locale_simple, levels = loc_levels))
 
-locale_rates <- summarise_reason_rates(by_locale, c("academic_year", "locale_simple"))
+locale_rates <- summarise_reason_rates(by_locale, c("academic_year", "locale_simple")) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 save_table(locale_rates, "20_locale_reason_rates.csv")
 
 p_locale_total <- plot_total_rate(distinct(locale_rates, academic_year, locale_simple, total_rate),


### PR DESCRIPTION
## Summary
- Factor `reason_lab` using `pal_reason` levels before plotting

## Testing
- `Rscript Analysis/20_suspension_reason_trends_by_level_and_locale.R` *(fails: cannot download R packages)*
- `Rscript -e 'testthat::test_dir("tests")'` *(fails: cannot download R packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ebebc5c8331879941bb4c017289