### PR TITLE
Coerce reason factors for consistent palettes

### DIFF
--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -140,7 +140,8 @@ plot_reason_area <- function(df, facet_col = NULL, title_txt) {
 }
 
 # --- 3) Overall trends -------------------------------------------------------
-overall_rates <- summarise_reason_rates(v6, "academic_year")
+overall_rates <- summarise_reason_rates(v6, "academic_year") %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 print(unique(overall_rates$reason_lab))
 print(names(pal_reason))
 print(setdiff(unique(overall_rates$reason_lab), names(pal_reason)))
@@ -164,7 +165,8 @@ by_grade <- v6 %>%
   filter(school_level %in% grade_levels) %>%
   mutate(school_level = factor(school_level, levels = grade_levels))
 
-grade_rates <- summarise_reason_rates(by_grade, c("academic_year", "school_level"))
+grade_rates <- summarise_reason_rates(by_grade, c("academic_year", "school_level")) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 save_table(grade_rates, "20_grade_reason_rates.csv")
 
 p_grade_total <- plot_total_rate(distinct(grade_rates, academic_year, school_level, total_rate),
@@ -187,7 +189,8 @@ by_locale <- v6 %>%
   filter(locale_simple %in% loc_levels) %>%
   mutate(locale_simple = factor(locale_simple, levels = loc_levels))
 
-locale_rates <- summarise_reason_rates(by_locale, c("academic_year", "locale_simple"))
+locale_rates <- summarise_reason_rates(by_locale, c("academic_year", "locale_simple")) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 save_table(locale_rates, "20_locale_reason_rates.csv")
 
 p_locale_total <- plot_total_rate(distinct(locale_rates, academic_year, locale_simple, total_rate),

--- a/R/07_explore_trends.R
+++ b/R/07_explore_trends.R
@@ -109,7 +109,10 @@ reason_rate_by_black_quartile <- black_students_data %>%
     enrollment = sum(cumulative_enrollment, na.rm = TRUE),
     .groups    = "drop"
   ) %>%
-  mutate(reason_rate = if_else(enrollment > 0, count / enrollment, NA_real_))
+  mutate(
+    reason_rate = if_else(enrollment > 0, count / enrollment, NA_real_),
+    reason_lab  = factor(reason_lab, levels = names(pal_reason))
+  )
 
 # Data for total labels in each facet
 labels_reason_black_q <- reason_rate_by_black_quartile %>%
@@ -200,7 +203,10 @@ reason_rate_by_white_quartile <- black_students_data %>%
     enrollment = sum(cumulative_enrollment, na.rm = TRUE),
     .groups    = "drop"
   ) %>%
-  mutate(reason_rate = if_else(enrollment > 0, count / enrollment, NA_real_))
+  mutate(
+    reason_rate = if_else(enrollment > 0, count / enrollment, NA_real_),
+    reason_lab  = factor(reason_lab, levels = names(pal_reason))
+  )
 
 labels_reason_white_q <- reason_rate_by_white_quartile %>%
   group_by(academic_year, white_prop_q_label) %>%

--- a/R/08_analysis_black_student_rates.R
+++ b/R/08_analysis_black_student_rates.R
@@ -88,7 +88,10 @@ reason_rate_by_black_quartile <- black_students_data %>%
     values_to = "count"
   ) %>%
   add_reason_label() %>%
-  mutate(reason_rate = if_else(enrollment > 0, (count / enrollment), 0))
+  mutate(
+    reason_rate = if_else(enrollment > 0, (count / enrollment), 0),
+    reason_lab  = factor(reason_lab, levels = names(pal_reason))
+  )
 
 # Data for total labels in each facet
 labels_reason_black_q <- reason_rate_by_black_quartile %>%
@@ -169,7 +172,10 @@ reason_rate_by_white_quartile <- black_students_data %>%
     values_to = "count"
   ) %>%
   add_reason_label() %>%
-  mutate(reason_rate = if_else(enrollment > 0, (count / enrollment), 0))
+  mutate(
+    reason_rate = if_else(enrollment > 0, (count / enrollment), 0),
+    reason_lab  = factor(reason_lab, levels = names(pal_reason))
+  )
 
 # Data for total labels in each facet
 labels_reason_white_q <- reason_rate_by_white_quartile %>%


### PR DESCRIPTION
## Summary
- Explicitly coerce `reason_lab` columns to factors with `names(pal_reason)` in analysis scripts
- Maintain consistent legend order for grade and locale reason plots

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: cannot download packages)*
- `Rscript Analysis/20_suspension_reason_trends_by_level_and_locale.R` *(fails: cannot download packages)*
- `Rscript R/07_explore_trends.R` *(fails: cannot download packages)*
- `Rscript R/08_analysis_black_student_rates.R` *(fails: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ec7965c8331ba59f0bf21d67d00