### PR TITLE
refactor: use canonical level subsets

### DIFF
--- a/Analysis/05b_rates_by_locale_facet_race_TWO.R
+++ b/Analysis/05b_rates_by_locale_facet_race_TWO.R
@@ -65,8 +65,7 @@ race_chunks <- split(race_order, chunk_id)
 message("Races split into ", length(race_chunks), " image(s).")
 
 # Locale palette and ordering
-loc_levels <- locale_levels
-if (!INCLUDE_UNKNOWN) loc_levels <- head(loc_levels, -1)
+loc_levels <- if (INCLUDE_UNKNOWN) locale_levels else locale_levels[locale_levels != "Unknown"]
 pal_locale_use <- pal_locale[loc_levels]
 
 # --- 4) Plot function ---------------------------------------------------------

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -91,8 +91,7 @@ if (KEEP_CORE_RACES_ONLY) df_all <- df_all %>% filter(race %in% CORE_RACES)
 if (!nrow(df_all)) stop("No data available after filtering.")
 
 # Locales to render
-loc_levels <- locale_levels
-if (!INCLUDE_UNKNOWN) loc_levels <- head(loc_levels, -1)
+loc_levels <- if (INCLUDE_UNKNOWN) locale_levels else locale_levels[locale_levels != "Unknown"]
 
 # --- 7) Plot function: one locale, race-faceted (≤2 panels) -------------------
 plot_locale_chunk <- function(dat_locale, races, loc_name, i, n_total) {

--- a/Analysis/08_locale_all_years_all_races_one_graph_each.R
+++ b/Analysis/08_locale_all_years_all_races_one_graph_each.R
@@ -58,7 +58,7 @@ df <- v6 %>%
   )
 
 # Locales to render (1 image per)
-loc_levels <- head(locale_levels, -1)
+loc_levels <- locale_levels[locale_levels != "Unknown"]
 
 # --- 5) Plot helper (Sharpened with Corrected Label Size) ----------------------
 plot_one_locale <- function(loc_name) {

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -76,8 +76,7 @@ df_level <- base %>%
 
 # B) Split by locale -> by LEVEL × LOCALE × RACE × YEAR
 # Locales to render
-loc_levels <- locale_levels
-if (!INCLUDE_UNKNOWN_LOCALE) loc_levels <- head(loc_levels, -1)
+loc_levels <- if (INCLUDE_UNKNOWN_LOCALE) locale_levels else locale_levels[locale_levels != "Unknown"]
 
 df_level_loc <- base %>%
   group_by(school_level, locale_simple, race, academic_year, year_fct) %>%

--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -159,7 +159,7 @@ ggsave(file.path(out_dir, "20_overall_reason_rates.png"), p_overall_reason,
        width = 10, height = 6, dpi = 300)
 
 # --- 4) By grade level -------------------------------------------------------
-grade_levels <- setdiff(LEVEL_LABELS, c("Other", "Alternative"))
+grade_levels <- LEVEL_LABELS[!LEVEL_LABELS %in% c("Other", "Alternative")]
 by_grade <- v6 %>%
   filter(school_level %in% grade_levels) %>%
   mutate(school_level = factor(school_level, levels = grade_levels))
@@ -182,7 +182,7 @@ ggsave(file.path(out_dir, "20_grade_reason_rates.png"), p_grade_reason,
        width = 12, height = 8, dpi = 300)
 
 # --- 5) By locale ------------------------------------------------------------
-loc_levels <- setdiff(locale_levels, "Unknown")
+loc_levels <- locale_levels[locale_levels != "Unknown"]
 by_locale <- v6 %>%
   filter(locale_simple %in% loc_levels) %>%
   mutate(locale_simple = factor(locale_simple, levels = loc_levels))


### PR DESCRIPTION
## Summary
- use subsets of `locale_levels` instead of ad-hoc locale vectors
- derive grade-level sets directly from `LEVEL_LABELS`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: unable to download renv packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ecd71f483319c86c52e9f4d4c18