### PR TITLE
Remove hardcoded raw file path and document env vars

### DIFF
--- a/R/00_paths.R
+++ b/R/00_paths.R
@@ -40,9 +40,7 @@ raw_candidates <- c(
   # 1) Optional override via environment variable RAW_PATH (set in ~/.Renviron or shell)
   Sys.getenv("RAW_PATH", unset = ""),
   # 2) Repo-relative default (portable across machines)
-  file.path(dp_raw, "copy_CDE_suspensions_1718-2324_sc_race.xlsx"),
-  # 3) Your original absolute path (kept as a fallback for this machine)
-  "/Users/michaelcorral/Library/CloudStorage/GoogleDrive-mdcorral@g.ucla.edu/.shortcut-targets-by-id/1qNAOKIg0UjuT3XWFlk4dkDLN6UPWJVGx/Center for the Transformation of Schools/Research/CA Race Education And Community Healing (REACH)/2. REACH Network (INTERNAL)/15. REACH Baseline Report_Summer 2025/6. R Data Analysis Project Folders/1. 250828_R Folder/copy_CDE_suspensions_1718-2324_sc_race.xlsx"
+  file.path(dp_raw, "copy_CDE_suspensions_1718-2324_sc_race.xlsx")
 )
 
 # drop blank strings so file.exists() won't get empty values

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ renv::restore()
 `R/utils_keys_filters.R` defines `canon_race_label()` and `ALLOWED_RACES` used across analyses. The function maps CRDC code `RD` and strings such as "Not Reported" to the canonical label "Not Reported." This category is tracked for completeness but omitted from plots to avoid conflating missing data with student populations.
 
 
+## Environment variables
+
+These optional environment variables allow the project to run without hard-coded paths. Set them in your shell or `.Renviron`.
+
+- `REACH_PROJECT_ROOT`: path to the project root. Defaults to the current working directory if unset.
+- `REACH_DATA_DIR`: directory for staged data files. Defaults to `data-stage/` under the project root.
+- `RAW_PATH`: full path to the raw Excel file `copy_CDE_suspensions_1718-2324_sc_race.xlsx`. Defaults to `data-raw/` under the project root.
+


### PR DESCRIPTION
## Summary
- Drop user-specific absolute path from raw file search and rely on environment variable `RAW_PATH` or repo-relative default.
- Describe `REACH_PROJECT_ROOT`, `REACH_DATA_DIR`, and `RAW_PATH` environment variables in the README.

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: cannot download packages during renv bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_68c6579f0df08331a8b1d266d87b70c9