### PR TITLE
Remove codex placeholders and clarify analysis comments

### DIFF
--- a/Analysis/05b_rates_by_locale_facet_race_TWO.R
+++ b/Analysis/05b_rates_by_locale_facet_race_TWO.R
@@ -65,7 +65,7 @@ race_chunks <- split(race_order, chunk_id)
 message("Races split into ", length(race_chunks), " image(s).")
 
 # Locale palette and ordering
-##codex/replace-local-grade-and-locale-lists-gfehth
+# Drop "Unknown" from locale palette
 loc_levels <- if (INCLUDE_UNKNOWN) locale_levels else setdiff(locale_levels, "Unknown")
 pal_locale_use <- pal_locale[loc_levels]
 

--- a/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
+++ b/Analysis/07_rates_trad_vs_other_by_race_by_locale.R
@@ -91,7 +91,6 @@ if (KEEP_CORE_RACES_ONLY) df_all <- df_all %>% filter(race %in% CORE_RACES)
 if (!nrow(df_all)) stop("No data available after filtering.")
 
 # Locales to render
-#codex/replace-local-grade-and-locale-lists-gfehth
 loc_levels <- if (INCLUDE_UNKNOWN) locale_levels else setdiff(locale_levels, "Unknown")
 
 

--- a/Analysis/08_locale_all_years_all_races_one_graph_each.R
+++ b/Analysis/08_locale_all_years_all_races_one_graph_each.R
@@ -58,7 +58,7 @@ df <- v6 %>%
   )
 
 # Locales to render (1 image per)
-#codex/replace-local-grade-and-locale-lists-gfehth
+# Drop "Unknown" from locale list
 loc_levels <- setdiff(locale_levels, "Unknown")
 
 

--- a/Analysis/09_rates_by_level_and_by_level_locale.R
+++ b/Analysis/09_rates_by_level_and_by_level_locale.R
@@ -76,7 +76,7 @@ df_level <- base %>%
 
 # B) Split by locale -> by LEVEL × LOCALE × RACE × YEAR
 # Locales to render
-$codex/replace-local-grade-and-locale-lists-gfehth
+# Choose which locales to include
 loc_levels <- if (INCLUDE_UNKNOWN_LOCALE) locale_levels else setdiff(locale_levels, "Unknown")
 
 

--- a/Analysis/19_statewide_rates_and_quartiles.R
+++ b/Analysis/19_statewide_rates_and_quartiles.R
@@ -1,6 +1,5 @@
 # analysis/19_statewide_rates_and_quartiles.R
 #
-##codex/create-statewide-data-frame-analysis-ke1b6
 # Build statewide suspension/enrollment totals prior to any filtering.
 # Also derive quartile summaries (e.g., by enrollment, racial proportion)
 # independent from those statewide totals.
@@ -19,7 +18,7 @@ source(here::here("R", "utils_keys_filters.R"))
 # ---- Load raw long file ------------------------------------------------------
 v6 <- read_parquet(here("data-stage", "susp_v6_long.parquet")) %>%
   build_keys() %>%
-##odex/create-statewide-data-frame-analysis-ke1b6u
+  # Keep only campus-level records
   filter_campus_only() %>%
   mutate(
     school_group = school_level,
@@ -97,7 +96,6 @@ write_parquet(
 )
 
 # ---- Quartile helpers --------------------------------------------------------
-##codex/create-statewide-data-frame-analysis-ke1b6u
 # Quartiles by total school enrollment (All Students baseline)
 # Ensure one row per school-year before assigning quartiles
 school_enroll <- v6 %>%
@@ -169,7 +167,6 @@ by_enrollment <- bind_rows(
 
 write_parquet(by_enrollment, here("data-stage", "quartile_rates_by_enrollment.parquet"))
 
-##codex/create-statewide-data-frame-analysis-ke1b6u
 
 # Quartiles by racial proportion example: Black share of enrollment
 # Compute proportion of Black enrollment out of school total and derive quartiles
@@ -197,7 +194,7 @@ all_enroll <- v6 %>%
   )
 
 black_prop <- v6 %>%
-##codex/update-deduplication-logic-in-enrollment-script
+  # Join Black student data with totals to compute proportions
   filter(subgroup == "Black/African American") %>%
   left_join(
     all_enroll,

--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -149,7 +149,7 @@ plot_reason_area <- function(df, facet_col = NULL, title_txt) {
 }
 
 # --- 3) Overall trends -------------------------------------------------------
-#codex/replace-local-grade-and-locale-lists-gfehth
+# Calculate overall statewide reason rates
 overall_rates <- summarise_reason_rates(v6, "academic_year") %>%
   mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 save_table(overall_rates, "20_overall_reason_rates.csv")

--- a/R/07_explore_trends.R
+++ b/R/07_explore_trends.R
@@ -110,7 +110,7 @@ reason_rate_by_black_quartile <- black_students_data %>%
     .groups    = "drop"
   ) %>%
   mutate(
-#codex/replace-local-grade-and-locale-lists-gfehth
+    # Convert reason labels to factors and compute rates
     reason_lab = factor(reason_lab, levels = names(pal_reason)),
     reason_rate = if_else(enrollment > 0, count / enrollment, NA_real_)
   )
@@ -204,7 +204,8 @@ reason_rate_by_white_quartile <- black_students_data %>%
     enrollment = sum(cumulative_enrollment, na.rm = TRUE),
     .groups    = "drop"
   ) %>%
-#codex/replace-local-grade-and-locale-lists-gfehth
+  mutate(
+    # Convert reason labels to factors and compute rates
     reason_lab = factor(reason_lab, levels = names(pal_reason)),
     reason_rate = if_else(enrollment > 0, count / enrollment, NA_real_)
   )

--- a/R/08_analysis_black_student_rates.R
+++ b/R/08_analysis_black_student_rates.R
@@ -89,7 +89,7 @@ reason_rate_by_black_quartile <- black_students_data %>%
   ) %>%
   add_reason_label() %>%
   mutate(
-#codex/replace-local-grade-and-locale-lists-gfehth
+    # Convert reason labels to factors and compute rates
     reason_lab   = factor(reason_lab, levels = names(pal_reason)),
     reason_rate  = if_else(enrollment > 0, (count / enrollment), 0)
   )
@@ -174,7 +174,7 @@ reason_rate_by_white_quartile <- black_students_data %>%
   ) %>%
   add_reason_label() %>%
   mutate(
-#codex/replace-local-grade-and-locale-lists-gfehth
+    # Convert reason labels to factors and compute rates
     reason_lab   = factor(reason_lab, levels = names(pal_reason)),
     reason_rate  = if_else(enrollment > 0, (count / enrollment), 0)
   )

--- a/R/22_build_v6_features.R
+++ b/R/22_build_v6_features.R
@@ -302,7 +302,7 @@ if (REBUILD_V6 || !file.exists(V6_FEAT_PARQ)) {
   # --- End of Corrected Block 1 ---
   
   # Ensure one row per campus-year
-##codex/add-assertion-for-unique-campus-year-keys-figr4y
+# Verify uniqueness of campus-year keys
   v6 <- assert_unique_campus(v6, year_col = "academic_year")
 
   # Range checks


### PR DESCRIPTION
## Summary
- Replace `codex/` placeholders with explanatory comments in analysis and feature scripts
- Clarify locale filtering and dataset handling across analysis files
- Emphasize campus-year uniqueness checks when building features

## Testing
- ⚠️ `Rscript run_pipeline.R` (missing package repository access)
- ⚠️ `Rscript --vanilla Analysis/08_locale_all_years_all_races_one_graph_each.R` (missing package `here`)


------
https://chatgpt.com/codex/tasks/task_e_68c657a327ac83318397e7a77735bbf1