### PR TITLE
Source paths within pipeline scripts

### DIFF
--- a/R/02_feature_locale_simple.R
+++ b/R/02_feature_locale_simple.R
@@ -8,6 +8,7 @@ suppressPackageStartupMessages({
   library(stringr)  # string helpers
 })
 
+source("R/00_paths.R")
 source(here::here("R", "utils_keys_filters.R"))
 
 message(">>> Running from project root: ", here::here())

--- a/R/02b_drop_charter_all.R
+++ b/R/02b_drop_charter_all.R
@@ -7,6 +7,7 @@ suppressPackageStartupMessages({
   library(dplyr)    # data wrangling
 })
 
+source("R/00_paths.R")
 message(">>> Running from project root: ", here::here())
 
 # -------------------------

--- a/R/03_feature_size_quartiles.R
+++ b/R/03_feature_size_quartiles.R
@@ -7,6 +7,7 @@ suppressPackageStartupMessages({
   library(dplyr)    # data wrangling
 })
 
+source("R/00_paths.R")
 message(">>> Running from project root: ", here::here())
 
 # 1) Read race-level table

--- a/R/03_feature_size_quartiles_TA.R
+++ b/R/03_feature_size_quartiles_TA.R
@@ -7,6 +7,7 @@ suppressPackageStartupMessages({
   library(dplyr)
 })
 
+source("R/00_paths.R")
 SHOW_SUMMARY <- TRUE
 source(here::here("R","utils_keys_filters.R"))
 message(">>> Running from project root: ", here::here())

--- a/R/04_feature_black_prop_quartiles.R
+++ b/R/04_feature_black_prop_quartiles.R
@@ -9,6 +9,7 @@ suppressPackageStartupMessages({
   library(tidyr)    # pivot_wider
 })
 
+source("R/00_paths.R")
 source(here::here("R","utils_keys_filters.R"))
 
 message(">>> Running from project root: ", here::here())

--- a/R/05_feature_school_level.R
+++ b/R/05_feature_school_level.R
@@ -11,6 +11,7 @@ suppressPackageStartupMessages({
   library(tibble)
 })
 # LEVEL_LABELS, span_label(), and is_alt() come from this utility
+source("R/00_paths.R")
 source(here::here("R","utils_keys_filters.R"))
 message(">>> Running from project root: ", here::here())
 

--- a/R/06_feature_reason_shares.R
+++ b/R/06_feature_reason_shares.R
@@ -9,6 +9,7 @@ suppressPackageStartupMessages({
   library(tidyr)    # pivot_longer
 })
 
+source("R/00_paths.R")
 message(">>> Running from project root: ", here::here())
 
 # canonical helpers (reason labels, palettes, etc.)

--- a/R/22_build_v6_features.R
+++ b/R/22_build_v6_features.R
@@ -18,8 +18,8 @@ V6_FEAT_PARQ <- file.path(DATA_STAGE, "susp_v6_features.parquet")
 V6_LONG_PARQ <- file.path(DATA_STAGE, "susp_v6_long.parquet")
 
 # -------------------- Repo utilities (optional) -------------------------------
+source("R/00_paths.R")
 if (file.exists(here("R","utils_keys_filters.R"))) source(here("R","utils_keys_filters.R"))
-if (file.exists(here("R","00_paths.R")))           source(here("R","00_paths.R"))
 
 # -------------------- Helpers --------------------------------------------------
 safe_div <- function(n, d) ifelse(is.na(d) | d <= 0, NA_real_, n / d)

--- a/run_pipeline.R
+++ b/run_pipeline.R
@@ -28,7 +28,6 @@ run <- function(f) {
 
 # --- assemble the script list (no archived [levels] variant) ----------------
 scripts <- c(
-  "R/00_paths.R",
   "R/01_ingest_v0.R",
   "R/02_feature_locale_simple.R",
   if (USE_TA) "R/02b_drop_charter_all.R",


### PR DESCRIPTION
## Summary
- Remove `R/00_paths.R` from the pipeline script list
- Source `R/00_paths.R` directly in each pipeline script so path config is available when scripts run individually

## Testing
- `Rscript run_pipeline.R` *(fails: unable to access R package repository to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c657a51eec833192804a44a61691d5