### PR TITLE
Document subgroup requirement in tail concentration analysis

### DIFF
--- a/Analysis/17_tail_concentration_by_level.R
+++ b/Analysis/17_tail_concentration_by_level.R
@@ -24,6 +24,7 @@ DATA_STAGE <- here("data-stage")
 req_cols <- c(
   "school_code", "academic_year", "cumulative_enrollment",
   "total_suspensions", "unduplicated_count_of_students_suspended_total",
+  # Ensure long-format files with subgroup info are selected
   "subgroup"
 )
 


### PR DESCRIPTION
## Summary
- Clarify that `subgroup` must be present when selecting suspension data, ensuring long-format parquet files are chosen.

## Testing
- `Rscript Analysis/17_tail_concentration_by_level.R` *(fails: cannot access https://packagemanager.posit.co)*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: cannot access https://packagemanager.posit.co)*

------
https://chatgpt.com/codex/tasks/task_e_68c664dce0f48331a9e46d52fc5a9c9f