### PR TITLE
Handle both year column names when joining features

### DIFF
--- a/Analysis/17_tail_concentration_by_level.R
+++ b/Analysis/17_tail_concentration_by_level.R
@@ -107,10 +107,12 @@ susp <- raw %>%
   filter(!is.na(year_num), enrollment > 0, !is.na(measure))
 
 # Load features for level and setting
-feat <- read_parquet(V6_FEAT) %>% clean_names() %>%
+feat <- read_parquet(V6_FEAT) %>% clean_names()
+year_col <- intersect(c("year", "academic_year"), names(feat))[1]
+feat <- feat %>%
   transmute(
     school_code = as.character(school_code),
-    year_char   = as.character(year),
+    year_char   = as.character(.data[[year_col]]),
     is_traditional,
     school_type
   )


### PR DESCRIPTION
## Summary
- Make tail concentration analysis robust to feature files that use either `year` or `academic_year`

## Testing
- `Rscript --vanilla Analysis/17_tail_concentration_by_level.R` *(fails: there is no package called ‘arrow’)*

------
https://chatgpt.com/codex/tasks/task_e_68c66ada561c8331bbb5c2390ea42eef