### PR TITLE
Refactor pipeline scripts to share run helper

### DIFF
--- a/R/run_helper.R
+++ b/R/run_helper.R
@@ -1,0 +1,14 @@
+# run_helper.R — shared helper for running pipeline scripts
+run <- function(f) {
+  message("\n=== Running: ", f, " ===")
+  tryCatch(
+    {
+      source(f, chdir = FALSE, local = new.env(parent = globalenv()))
+      message("✓ Finished: ", f)
+    },
+    error = function(e) {
+      message("✗ Error in ", f, "\n", conditionMessage(e))
+      stop(e)
+    }
+  )
+}

--- a/run_all.R
+++ b/run_all.R
@@ -2,20 +2,7 @@
 
 message("=== REACH: full pipeline start @ ", format(Sys.time(), usetz = TRUE), " ===")
 
-# Reuse the same helper signature as run_pipeline.R
-run <- function(f) {
-  message("\n=== Running: ", f, " ===")
-  tryCatch(
-    {
-      source(f, chdir = FALSE, local = new.env(parent = globalenv()))
-      message("✓ Finished: ", f)
-    },
-    error = function(e) {
-      message("✗ Error in ", f, "\n", conditionMessage(e))
-      stop(e)
-    }
-  )
-}
+source("R/run_helper.R")
 
 # 1) Core build (00–06, with USE_TA toggle inside run_pipeline.R)
 run("run_pipeline.R")

--- a/run_pipeline.R
+++ b/run_pipeline.R
@@ -12,19 +12,7 @@ on.exit(options(pipeline_running = FALSE), add = TRUE)
 USE_TA <- TRUE   # TRUE = R/03_feature_size_quartiles_TA.R, FALSE = R/03_feature_size_quartiles.R
 
 # --- helper: source with progress + basic error handling --------------------
-run <- function(f) {
-  message("\n=== Running: ", f, " ===")
-  tryCatch(
-    {
-      source(f, chdir = FALSE, local = new.env(parent = globalenv()))
-      message("✓ Finished: ", f)
-    },
-    error = function(e) {
-      message("✗ Error in ", f, "\n", conditionMessage(e))
-      stop(e)
-    }
-  )
-}
+source("R/run_helper.R")
 
 # --- assemble the script list (no archived [levels] variant) ----------------
 scripts <- c(


### PR DESCRIPTION
## Summary
- add `R/run_helper.R` with the shared `run()` helper that wraps `source()` with logging and error handling
- update `run_all.R` and `run_pipeline.R` to reuse the helper and remove the duplicated definitions

## Testing
- Rscript run_pipeline.R *(fails: `Rscript` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c870151d248331976695aa3ccf2373