### PR TITLE
Add graph scripts for statewide and elementary suspension analyses

### DIFF
--- a/graph_scripts/01_statewide_disparities.R
+++ b/graph_scripts/01_statewide_disparities.R
@@ -1,0 +1,116 @@
+# graph_scripts/01_statewide_disparities.R
+# Line graph of statewide suspension rates by race/ethnicity across years.
+
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(ggplot2)
+  library(glue)
+  library(here)
+  library(scales)
+})
+
+source(here::here("graph_scripts", "graph_utils.R"))
+
+extract_rate <- function(df, group_name) {
+  vals <- df %>% dplyr::filter(subgroup == group_name) %>% dplyr::pull(rate)
+  if (length(vals) == 0) NA_real_ else vals[1]
+}
+
+joined <- load_joined_data()
+
+statewide_base <- joined %>%
+  dplyr::filter(
+    is_traditional,
+    subgroup %in% race_levels,
+    !is.na(total_suspensions),
+    !is.na(cumulative_enrollment),
+    cumulative_enrollment > 0
+  )
+
+year_levels <- statewide_base$academic_year %>% unique() %>% sort()
+
+statewide_rates <- statewide_base %>%
+  dplyr::group_by(academic_year, subgroup) %>%
+  dplyr::summarise(
+    suspensions = sum(total_suspensions, na.rm = TRUE),
+    enrollment = sum(cumulative_enrollment, na.rm = TRUE),
+    rate = safe_div(suspensions, enrollment),
+    .groups = "drop"
+  ) %>%
+  dplyr::filter(!is.na(rate)) %>%
+  dplyr::mutate(
+    academic_year = factor(academic_year, levels = year_levels),
+    subgroup = factorize_race(subgroup)
+  )
+
+latest_year <- latest_year_available(statewide_rates$academic_year)
+
+label_data <- statewide_rates %>%
+  dplyr::filter(as.character(academic_year) == latest_year) %>%
+  dplyr::mutate(label = scales::percent(rate, accuracy = 0.1))
+
+plot_statewide <- ggplot(statewide_rates,
+                         aes(x = academic_year, y = rate,
+                             color = subgroup, group = subgroup)) +
+  geom_line(linewidth = 1.1) +
+  geom_point(size = 2.7) +
+  geom_text(data = label_data,
+            aes(label = label),
+            position = position_nudge(x = 0.18),
+            hjust = 0,
+            size = 3,
+            show.legend = FALSE) +
+  scale_color_manual(values = race_palette, guide = guide_legend(nrow = 2)) +
+  scale_x_discrete(expand = expansion(mult = c(0.01, 0.25))) +
+  scale_y_continuous(labels = scales::percent_format(accuracy = 0.1),
+                     expand = expansion(mult = c(0, 0.1))) +
+  coord_cartesian(clip = "off") +
+  labs(
+    title = "Statewide Suspension Rates by Race/Ethnicity",
+    subtitle = "Traditional schools • All grades • Rate = total suspensions ÷ cumulative enrollment",
+    x = NULL,
+    y = "Suspension rate",
+    color = "Student group",
+    caption = "Source: California statewide suspension data (susp_v5 + v6 features)"
+  ) +
+  theme_reach()
+
+out_path <- file.path(OUTPUT_DIR, "statewide_race_trends.png")
+
+ggsave(out_path, plot_statewide, width = 12, height = 7, dpi = 320)
+
+latest_summary <- label_data %>% dplyr::select(subgroup, rate)
+black_rate <- extract_rate(latest_summary, "Black/African American")
+white_rate <- extract_rate(latest_summary, "White")
+hisp_rate  <- extract_rate(latest_summary, "Hispanic/Latino")
+asian_rate <- extract_rate(latest_summary, "Asian")
+ratio_bw <- if (!is.na(black_rate) && !is.na(white_rate) && white_rate > 0) black_rate / white_rate else NA_real_
+change_text <- statewide_rates %>%
+  dplyr::group_by(subgroup) %>%
+  dplyr::summarise(
+    first_rate = dplyr::first(rate),
+    last_rate  = dplyr::last(rate),
+    .groups = "drop"
+  ) %>%
+  dplyr::filter(subgroup %in% c("Black/African American", "White"))
+
+trend_dir <- if (nrow(change_text) == 2 && all(!is.na(change_text$first_rate), !is.na(change_text$last_rate))) {
+  diff_black <- change_text$last_rate[change_text$subgroup == "Black/African American"] -
+    change_text$first_rate[change_text$subgroup == "Black/African American"]
+  diff_white <- change_text$last_rate[change_text$subgroup == "White"] -
+    change_text$first_rate[change_text$subgroup == "White"]
+  if (diff_black > 0.001 | diff_white > 0.001) "re-opened era increases" else "slight shifts"
+} else {
+  "persistent gaps"
+}
+
+desc_text <- glue(
+  "Across the statewide series, Black students face the steepest suspension burden every year. " ,
+  "In {latest_year}, {scales::percent(black_rate, accuracy = 0.1)} of Black students were suspended statewide—", 
+  "{scales::number(ratio_bw, accuracy = 0.1)} times the rate for White students ({scales::percent(white_rate, accuracy = 0.1)}) and nearly double the Hispanic/Latino rate ({scales::percent(hisp_rate, accuracy = 0.1)}). ",
+  "Asian students remain the lowest at {scales::percent(asian_rate, accuracy = 0.1)}, underscoring {trend_dir} rather than any real narrowing of racial gaps."
+)
+
+write_description(desc_text, "statewide_race_trends.txt")
+
+message("Saved plot to ", out_path)

--- a/graph_scripts/02_statewide_quartiles.R
+++ b/graph_scripts/02_statewide_quartiles.R
@@ -1,0 +1,104 @@
+# graph_scripts/02_statewide_quartiles.R
+# Clustered bar chart comparing statewide rates to Q4 Black-enrollment schools by race.
+
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(ggplot2)
+  library(glue)
+  library(here)
+  library(scales)
+})
+
+source(here::here("graph_scripts", "graph_utils.R"))
+
+calc_rates <- function(df) {
+  df %>%
+    dplyr::group_by(subgroup) %>%
+    dplyr::summarise(
+      suspensions = sum(total_suspensions, na.rm = TRUE),
+      enrollment = sum(cumulative_enrollment, na.rm = TRUE),
+      rate = safe_div(suspensions, enrollment),
+      .groups = "drop"
+    ) %>%
+    dplyr::filter(!is.na(rate)) %>%
+    dplyr::mutate(subgroup = factorize_race(subgroup))
+}
+
+joined <- load_joined_data()
+
+quartile_base <- joined %>%
+  dplyr::filter(
+    is_traditional,
+    subgroup %in% race_levels,
+    !is.na(total_suspensions),
+    !is.na(cumulative_enrollment),
+    cumulative_enrollment > 0
+  )
+
+year_levels <- quartile_base$academic_year %>% unique() %>% sort()
+analysis_year <- latest_year_available(year_levels)
+
+if (is.na(analysis_year)) {
+  stop("No academic year available for quartile comparison")
+}
+
+latest_slice <- quartile_base %>% dplyr::filter(academic_year == analysis_year)
+
+statewide_rates <- calc_rates(latest_slice) %>%
+  dplyr::mutate(comparison = "Statewide Traditional Average")
+
+q4_rates <- latest_slice %>%
+  dplyr::filter(black_prop_q == 4 | black_prop_q_label == "Q4 (Highest % Black)") %>%
+  calc_rates() %>%
+  dplyr::mutate(comparison = "Q4: Highest Black Enrollment")
+
+bars <- dplyr::bind_rows(statewide_rates, q4_rates) %>%
+  dplyr::mutate(
+    comparison = factor(comparison, levels = names(comparison_palette)),
+    subgroup = forcats::fct_relevel(subgroup, race_levels)
+  )
+
+plot_quartiles <- ggplot(bars,
+                          aes(x = subgroup, y = rate, fill = comparison)) +
+  geom_col(position = position_dodge(width = 0.72), width = 0.68, color = NA) +
+  geom_text(aes(label = scales::percent(rate, accuracy = 0.1)),
+            position = position_dodge(width = 0.72),
+            vjust = -0.25,
+            size = 3,
+            color = "#2E2E2E") +
+  scale_fill_manual(values = comparison_palette, name = NULL) +
+  scale_y_continuous(labels = scales::percent_format(accuracy = 0.1),
+                     expand = expansion(mult = c(0, 0.12))) +
+  labs(
+    title = glue("Suspension Rates by Race/Ethnicity — {analysis_year}"),
+    subtitle = "Traditional schools statewide vs. schools in the highest quartile of Black enrollment",
+    x = NULL,
+    y = "Suspension rate",
+    caption = "Source: California statewide suspension data (susp_v5 + v6 features)"
+  ) +
+  theme_reach() +
+  theme(axis.text.x = element_text(angle = 35, hjust = 1))
+
+out_path <- file.path(OUTPUT_DIR, "statewide_quartile_comparison.png")
+
+ggsave(out_path, plot_quartiles, width = 11, height = 7, dpi = 320)
+
+black_state <- statewide_rates %>% dplyr::filter(subgroup == "Black/African American") %>% dplyr::pull(rate)
+black_q4    <- q4_rates %>% dplyr::filter(subgroup == "Black/African American") %>% dplyr::pull(rate)
+white_state <- statewide_rates %>% dplyr::filter(subgroup == "White") %>% dplyr::pull(rate)
+white_q4    <- q4_rates %>% dplyr::filter(subgroup == "White") %>% dplyr::pull(rate)
+
+spread_black <- if (length(black_state) > 0 && length(black_q4) > 0) black_q4[1] - black_state[1] else NA_real_
+spread_white <- if (length(white_state) > 0 && length(white_q4) > 0) white_q4[1] - white_state[1] else NA_real_
+ratio_black  <- if (!is.na(black_state[1]) && black_state[1] > 0) black_q4[1] / black_state[1] else NA_real_
+
+quartile_text <- glue(
+  "In {analysis_year}, statewide traditional schools suspended Black students at {scales::percent(black_state, accuracy = 0.1)}. ",
+  "In the highest-Black-enrollment campuses the rate climbed to {scales::percent(black_q4, accuracy = 0.1)}—",
+  "an increase of {scales::percent(spread_black, accuracy = 0.1)} and {scales::number(ratio_black, accuracy = 0.1)}× the statewide average. ",
+  "White students also see a bump from {scales::percent(white_state, accuracy = 0.1)} statewide to {scales::percent(white_q4, accuracy = 0.1)} in Q4 schools, indicating that discipline practices in high-Black-enrollment campuses elevate suspensions for every group while leaving Black students with the highest burden."
+)
+
+write_description(quartile_text, "statewide_quartile_comparison.txt")
+
+message("Saved plot to ", out_path)

--- a/graph_scripts/03_elementary_disparities.R
+++ b/graph_scripts/03_elementary_disparities.R
@@ -1,0 +1,115 @@
+# graph_scripts/03_elementary_disparities.R
+# Line graph of elementary traditional school suspension rates by race/ethnicity.
+
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(ggplot2)
+  library(glue)
+  library(here)
+  library(scales)
+  library(tidyr)
+})
+
+source(here::here("graph_scripts", "graph_utils.R"))
+
+extract_rate <- function(df, group_name) {
+  vals <- df %>% dplyr::filter(subgroup == group_name) %>% dplyr::pull(rate)
+  if (length(vals) == 0) NA_real_ else vals[1]
+}
+
+joined <- load_joined_data()
+
+elem_base <- joined %>%
+  dplyr::filter(
+    is_traditional,
+    school_level == "Elementary",
+    subgroup %in% race_levels,
+    !is.na(total_suspensions),
+    !is.na(cumulative_enrollment),
+    cumulative_enrollment > 0
+  )
+
+year_levels <- elem_base$academic_year %>% unique() %>% sort()
+earliest_year <- if (length(year_levels) > 0) year_levels[1] else NA_character_
+
+elem_rates <- elem_base %>%
+  dplyr::group_by(academic_year, subgroup) %>%
+  dplyr::summarise(
+    suspensions = sum(total_suspensions, na.rm = TRUE),
+    enrollment = sum(cumulative_enrollment, na.rm = TRUE),
+    rate = safe_div(suspensions, enrollment),
+    .groups = "drop"
+  ) %>%
+  dplyr::filter(!is.na(rate)) %>%
+  dplyr::mutate(
+    academic_year = factor(academic_year, levels = year_levels),
+    subgroup = factorize_race(subgroup)
+  )
+
+latest_year <- latest_year_available(elem_rates$academic_year)
+
+label_data <- elem_rates %>%
+  dplyr::filter(as.character(academic_year) == latest_year) %>%
+  dplyr::mutate(label = scales::percent(rate, accuracy = 0.1))
+
+plot_elem <- ggplot(elem_rates,
+                    aes(x = academic_year, y = rate, color = subgroup, group = subgroup)) +
+  geom_line(linewidth = 1.05) +
+  geom_point(size = 2.6) +
+  geom_text(data = label_data,
+            aes(label = label),
+            position = position_nudge(x = 0.18),
+            hjust = 0,
+            size = 3,
+            show.legend = FALSE) +
+  scale_color_manual(values = race_palette, guide = guide_legend(nrow = 2)) +
+  scale_x_discrete(expand = expansion(mult = c(0.01, 0.25))) +
+  scale_y_continuous(labels = scales::percent_format(accuracy = 0.1),
+                     expand = expansion(mult = c(0, 0.1))) +
+  coord_cartesian(clip = "off") +
+  labs(
+    title = "Elementary Suspension Rates by Race/Ethnicity",
+    subtitle = "Traditional elementary schools • Rate = total suspensions ÷ cumulative enrollment",
+    x = NULL,
+    y = "Suspension rate",
+    color = "Student group",
+    caption = "Source: California statewide suspension data (susp_v5 + v6 features)"
+  ) +
+  theme_reach()
+
+out_path <- file.path(OUTPUT_DIR, "elementary_race_trends.png")
+
+ggsave(out_path, plot_elem, width = 12, height = 7, dpi = 320)
+
+latest_summary <- label_data %>% dplyr::select(subgroup, rate)
+black_rate <- extract_rate(latest_summary, "Black/African American")
+white_rate <- extract_rate(latest_summary, "White")
+hisp_rate  <- extract_rate(latest_summary, "Hispanic/Latino")
+ratio_bw <- if (!is.na(black_rate) && !is.na(white_rate) && white_rate > 0) black_rate / white_rate else NA_real_
+
+opening_gap <- elem_rates %>%
+  dplyr::filter(as.character(academic_year) == earliest_year,
+                subgroup %in% c("Black/African American", "White")) %>%
+  tidyr::pivot_wider(names_from = subgroup, values_from = rate)
+
+opening_ratio <- if (nrow(opening_gap) == 1 && !is.na(opening_gap$`White`)) {
+  opening_gap$`Black/African American` / opening_gap$`White`
+} else {
+  NA_real_
+}
+
+history_sentence <- if (!is.na(opening_ratio) && opening_ratio > 0) {
+  glue("The Black–White gap has persisted since the first year of the series at roughly {scales::number(opening_ratio, accuracy = 0.1)}× the White rate.")
+} else {
+  "The Black–White gap has persisted since the first year of the series with no sign of closing."
+}
+
+desc_text <- glue(
+  "Disparities emerge in the earliest grades. In {latest_year}, {scales::percent(black_rate, accuracy = 0.1)} of Black elementary students were suspended statewide—",
+  "{scales::number(ratio_bw, accuracy = 0.1)} times the rate for White peers ({scales::percent(white_rate, accuracy = 0.1)}) and well above Hispanic/Latino classmates ({scales::percent(hisp_rate, accuracy = 0.1)}). ",
+  history_sentence
+)
+
+write_description(desc_text, "elementary_race_trends.txt")
+
+message("Saved plot to ", out_path)

--- a/graph_scripts/04_elementary_quartiles.R
+++ b/graph_scripts/04_elementary_quartiles.R
@@ -1,0 +1,102 @@
+# graph_scripts/04_elementary_quartiles.R
+# Clustered bar chart for elementary traditional schools comparing statewide vs Q4 Black enrollment.
+
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(ggplot2)
+  library(glue)
+  library(here)
+  library(scales)
+})
+
+source(here::here("graph_scripts", "graph_utils.R"))
+
+calc_rates <- function(df) {
+  df %>%
+    dplyr::group_by(subgroup) %>%
+    dplyr::summarise(
+      suspensions = sum(total_suspensions, na.rm = TRUE),
+      enrollment = sum(cumulative_enrollment, na.rm = TRUE),
+      rate = safe_div(suspensions, enrollment),
+      .groups = "drop"
+    ) %>%
+    dplyr::filter(!is.na(rate)) %>%
+    dplyr::mutate(subgroup = factorize_race(subgroup))
+}
+
+joined <- load_joined_data()
+
+elem_base <- joined %>%
+  dplyr::filter(
+    is_traditional,
+    school_level == "Elementary",
+    subgroup %in% race_levels,
+    !is.na(total_suspensions),
+    !is.na(cumulative_enrollment),
+    cumulative_enrollment > 0
+  )
+
+year_levels <- elem_base$academic_year %>% unique() %>% sort()
+analysis_year <- latest_year_available(year_levels)
+
+if (is.na(analysis_year)) {
+  stop("No academic year available for elementary quartile comparison")
+}
+
+latest_slice <- elem_base %>% dplyr::filter(academic_year == analysis_year)
+
+statewide_rates <- calc_rates(latest_slice) %>%
+  dplyr::mutate(comparison = "Statewide Traditional Average")
+
+q4_rates <- latest_slice %>%
+  dplyr::filter(black_prop_q == 4 | black_prop_q_label == "Q4 (Highest % Black)") %>%
+  calc_rates() %>%
+  dplyr::mutate(comparison = "Q4: Highest Black Enrollment")
+
+bars <- dplyr::bind_rows(statewide_rates, q4_rates) %>%
+  dplyr::mutate(
+    comparison = factor(comparison, levels = names(comparison_palette)),
+    subgroup = forcats::fct_relevel(subgroup, race_levels)
+  )
+
+plot_elem_quartiles <- ggplot(bars,
+                               aes(x = subgroup, y = rate, fill = comparison)) +
+  geom_col(position = position_dodge(width = 0.72), width = 0.68, color = NA) +
+  geom_text(aes(label = scales::percent(rate, accuracy = 0.1)),
+            position = position_dodge(width = 0.72),
+            vjust = -0.25,
+            size = 3,
+            color = "#2E2E2E") +
+  scale_fill_manual(values = comparison_palette, name = NULL) +
+  scale_y_continuous(labels = scales::percent_format(accuracy = 0.1),
+                     expand = expansion(mult = c(0, 0.12))) +
+  labs(
+    title = glue("Elementary Suspension Rates — {analysis_year}"),
+    subtitle = "Traditional elementary schools statewide vs. highest-Black-enrollment campuses",
+    x = NULL,
+    y = "Suspension rate",
+    caption = "Source: California statewide suspension data (susp_v5 + v6 features)"
+  ) +
+  theme_reach() +
+  theme(axis.text.x = element_text(angle = 35, hjust = 1))
+
+out_path <- file.path(OUTPUT_DIR, "elementary_quartile_comparison.png")
+
+ggsave(out_path, plot_elem_quartiles, width = 11, height = 7, dpi = 320)
+
+black_state <- statewide_rates %>% dplyr::filter(subgroup == "Black/African American") %>% dplyr::pull(rate)
+black_q4    <- q4_rates %>% dplyr::filter(subgroup == "Black/African American") %>% dplyr::pull(rate)
+hisp_state  <- statewide_rates %>% dplyr::filter(subgroup == "Hispanic/Latino") %>% dplyr::pull(rate)
+hisp_q4     <- q4_rates %>% dplyr::filter(subgroup == "Hispanic/Latino") %>% dplyr::pull(rate)
+
+spread_black <- if (length(black_state) > 0 && length(black_q4) > 0) black_q4[1] - black_state[1] else NA_real_
+spread_hisp  <- if (length(hisp_state) > 0 && length(hisp_q4) > 0) hisp_q4[1] - hisp_state[1] else NA_real_
+
+summary_text <- glue(
+  "Even in elementary grades, high-Black-enrollment schools drive sharper discipline. {scales::percent(black_state, accuracy = 0.1)} of Black students were suspended statewide in {analysis_year}, but the rate jumps to {scales::percent(black_q4, accuracy = 0.1)} in Q4 campuses—an extra {scales::percent(spread_black, accuracy = 0.1)}. ",
+  "Hispanic/Latino students also see higher rates ({scales::percent(hisp_state, accuracy = 0.1)} statewide vs. {scales::percent(hisp_q4, accuracy = 0.1)} in Q4), showing that concentrated discipline practices impact multiple groups while still falling hardest on Black children."
+)
+
+write_description(summary_text, "elementary_quartile_comparison.txt")
+
+message("Saved plot to ", out_path)

--- a/graph_scripts/05_unequal_burden.R
+++ b/graph_scripts/05_unequal_burden.R
@@ -1,0 +1,139 @@
+# graph_scripts/05_unequal_burden.R
+# Line graph showing concentration of suspensions among a small share of schools.
+
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(ggplot2)
+  library(glue)
+  library(here)
+  library(scales)
+})
+
+source(here::here("graph_scripts", "graph_utils.R"))
+
+calc_top_share <- function(df, label, top_frac = 0.10) {
+  df %>%
+    dplyr::group_by(academic_year) %>%
+    dplyr::group_modify(~{
+      school_totals <- .x %>%
+        dplyr::group_by(school_code) %>%
+        dplyr::summarise(total_susp = sum(total_suspensions, na.rm = TRUE), .groups = "drop") %>%
+        dplyr::filter(!is.na(total_susp)) %>%
+        dplyr::arrange(dplyr::desc(total_susp))
+      n_schools <- nrow(school_totals)
+      if (n_schools == 0) {
+        return(tibble::tibble())
+      }
+      top_n <- max(1, floor(top_frac * n_schools))
+      total_sum <- sum(school_totals$total_susp, na.rm = TRUE)
+      top_sum <- sum(school_totals$total_susp[seq_len(top_n)], na.rm = TRUE)
+      tibble::tibble(
+        academic_year = unique(.x$academic_year),
+        setting = label,
+        top_share = safe_div(top_sum, total_sum),
+        top_schools = top_n,
+        total_schools = n_schools
+      )
+    }) %>%
+    dplyr::ungroup()
+}
+
+joined <- load_joined_data()
+
+susp_base <- joined %>%
+  dplyr::filter(
+    is_traditional,
+    subgroup %in% c("All Students", "Total"),
+    !is.na(total_suspensions),
+    total_suspensions >= 0
+  ) %>%
+  dplyr::mutate(academic_year = as.character(academic_year))
+
+series_all <- calc_top_share(susp_base, "All Traditional Schools")
+series_elem <- calc_top_share(
+  susp_base %>% dplyr::filter(school_level == "Elementary"),
+  "Elementary Traditional Schools"
+)
+
+series <- dplyr::bind_rows(series_all, series_elem)
+
+year_levels <- series$academic_year %>% unique() %>% sort()
+
+series <- series %>%
+  dplyr::mutate(
+    academic_year = factor(academic_year, levels = year_levels),
+    setting = factor(setting, levels = names(setting_palette))
+  ) %>%
+  dplyr::filter(!is.na(top_share))
+
+latest_year <- latest_year_available(series$academic_year)
+label_data <- series %>%
+  dplyr::filter(as.character(academic_year) == latest_year) %>%
+  dplyr::mutate(label = scales::percent(top_share, accuracy = 0.1))
+
+plot_concentration <- ggplot(series,
+                             aes(x = academic_year, y = top_share, color = setting, group = setting)) +
+  geom_line(linewidth = 1.05) +
+  geom_point(size = 2.6) +
+  geom_text(data = label_data,
+            aes(label = label),
+            position = position_nudge(x = 0.18),
+            hjust = 0,
+            size = 3,
+            show.legend = FALSE) +
+  scale_color_manual(values = setting_palette, name = NULL) +
+  scale_x_discrete(expand = expansion(mult = c(0.02, 0.22))) +
+  scale_y_continuous(labels = scales::percent_format(accuracy = 0.1),
+                     expand = expansion(mult = c(0, 0.08))) +
+  coord_cartesian(clip = "off") +
+  labs(
+    title = "Suspensions Cluster in a Small Share of Schools",
+    subtitle = "Share of total suspensions attributed to the top 10% of schools (by suspensions)",
+    x = NULL,
+    y = "Share of suspensions",
+    caption = "Source: California statewide suspension data (susp_v5 + v6 features)"
+  ) +
+  theme_reach()
+
+out_path <- file.path(OUTPUT_DIR, "unequal_burden_top10.png")
+
+ggsave(out_path, plot_concentration, width = 11.5, height = 7, dpi = 320)
+
+fmt_percent <- function(x) if (!is.na(x)) scales::percent(x, accuracy = 0.1) else "N/A"
+
+first_year <- if (length(year_levels) > 0) year_levels[1] else NA_character_
+latest_all <- label_data %>% dplyr::filter(setting == "All Traditional Schools")
+latest_elem <- label_data %>% dplyr::filter(setting == "Elementary Traditional Schools")
+first_all <- series %>% dplyr::filter(setting == "All Traditional Schools", as.character(academic_year) == first_year)
+first_elem <- series %>% dplyr::filter(setting == "Elementary Traditional Schools", as.character(academic_year) == first_year)
+
+pull_value <- function(df, col) {
+  if (nrow(df) == 0) {
+    return(NA)
+  }
+  val <- df[[col]]
+  if (length(val) == 0) NA else val[1]
+}
+
+share_all_now   <- pull_value(latest_all, "top_share")
+share_elem_now  <- pull_value(latest_elem, "top_share")
+share_all_first <- pull_value(first_all, "top_share")
+share_elem_first<- pull_value(first_elem, "top_share")
+top_school_count<- pull_value(latest_all, "top_schools")
+total_school_ct <- pull_value(latest_all, "total_schools")
+
+top_school_phrase <- if (!is.na(top_school_count) && !is.na(total_school_ct)) {
+  glue("{top_school_count} campuses out of {total_school_ct}")
+} else {
+  "a small set of campuses"
+}
+
+concentration_text <- glue(
+  "The top decile of traditional schools accounted for {fmt_percent(share_all_now)} of statewide suspensions in {latest_year}, meaning {top_school_phrase} carry that share. ",
+  "Elementary campuses show similar concentration: the top decile captured {fmt_percent(share_elem_now)} of suspensions in {latest_year}, compared with {fmt_percent(share_elem_first)} in {first_year}. ",
+  "Statewide, the share shifted from {fmt_percent(share_all_first)} in {first_year}, underscoring how a small cluster of schools continues to shoulder most suspensions."
+)
+
+write_description(concentration_text, "unequal_burden_top10.txt")
+
+message("Saved plot to ", out_path)

--- a/graph_scripts/graph_utils.R
+++ b/graph_scripts/graph_utils.R
@@ -1,0 +1,136 @@
+# graph_scripts/graph_utils.R
+# Shared helpers for suspension rate graphics.
+
+suppressPackageStartupMessages({
+  library(arrow)
+  library(dplyr)
+  library(forcats)
+  library(glue)
+  library(here)
+  library(janitor)
+  library(scales)
+  library(stringr)
+})
+
+DATA_STAGE <- here::here("data-stage")
+SUSP_PATH  <- file.path(DATA_STAGE, "susp_v5.parquet")
+FEAT_PATH  <- file.path(DATA_STAGE, "susp_v6_features.parquet")
+OUTPUT_DIR <- here::here("outputs", "graphs")
+TEXT_DIR   <- file.path(OUTPUT_DIR, "descriptions")
+
+dir.create(OUTPUT_DIR, recursive = TRUE, showWarnings = FALSE)
+dir.create(TEXT_DIR,   recursive = TRUE, showWarnings = FALSE)
+
+race_levels <- c(
+  "Black/African American",
+  "Hispanic/Latino",
+  "White",
+  "Asian",
+  "American Indian/Alaska Native",
+  "Native Hawaiian/Pacific Islander",
+  "Filipino",
+  "Two or More Races"
+)
+
+race_palette <- c(
+  "Black/African American"          = "#D62828",
+  "Hispanic/Latino"                 = "#F77F00",
+  "White"                           = "#003049",
+  "Asian"                           = "#2A9D8F",
+  "American Indian/Alaska Native"   = "#8E7DBE",
+  "Native Hawaiian/Pacific Islander"= "#577590",
+  "Filipino"                        = "#E9C46A",
+  "Two or More Races"               = "#588157"
+)
+
+comparison_palette <- c(
+  "Statewide Traditional Average"   = "#3B6FB6",
+  "Q4: Highest Black Enrollment"    = "#D1495B"
+)
+
+setting_palette <- c(
+  "All Traditional Schools"         = "#3B6FB6",
+  "Elementary Traditional Schools"  = "#F4A261"
+)
+
+safe_div <- function(n, d) ifelse(is.na(d) | d == 0, NA_real_, n / d)
+
+standardize_quartile_label <- function(x) {
+  x <- as.character(x)
+  dplyr::case_when(
+    stringr::str_detect(x, stringr::regex("^q1", ignore_case = TRUE)) ~ "Q1 (Lowest % Black)",
+    stringr::str_detect(x, stringr::regex("^q2", ignore_case = TRUE)) ~ "Q2",
+    stringr::str_detect(x, stringr::regex("^q3", ignore_case = TRUE)) ~ "Q3",
+    stringr::str_detect(x, stringr::regex("^q4", ignore_case = TRUE)) ~ "Q4 (Highest % Black)",
+    TRUE ~ NA_character_
+  )
+}
+
+load_joined_data <- function() {
+  stopifnot(file.exists(SUSP_PATH), file.exists(FEAT_PATH))
+
+  susp <- arrow::read_parquet(SUSP_PATH) %>%
+    janitor::clean_names() %>%
+    dplyr::transmute(
+      school_code = as.character(school_code),
+      academic_year = as.character(academic_year),
+      subgroup = as.character(subgroup),
+      cumulative_enrollment = as.numeric(cumulative_enrollment),
+      total_suspensions = as.numeric(total_suspensions),
+      school_level = as.character(school_level),
+      school_type = as.character(school_type),
+      black_prop_q = as.integer(black_prop_q),
+      black_prop_q_label = as.character(black_prop_q_label)
+    )
+
+  feat <- arrow::read_parquet(FEAT_PATH) %>%
+    janitor::clean_names() %>%
+    dplyr::transmute(
+      school_code = as.character(school_code),
+      academic_year = as.character(academic_year),
+      is_traditional = !is.na(is_traditional) & is_traditional,
+      feat_black_q = as.integer(black_prop_q),
+      feat_black_q_label = as.character(black_prop_q_label)
+    )
+
+  susp %>%
+    dplyr::left_join(feat, by = c("school_code", "academic_year")) %>%
+    dplyr::mutate(
+      is_traditional = dplyr::coalesce(is_traditional, FALSE),
+      black_prop_q = dplyr::coalesce(feat_black_q, black_prop_q),
+      black_prop_q_label = dplyr::coalesce(feat_black_q_label, black_prop_q_label),
+      black_prop_q_label = standardize_quartile_label(black_prop_q_label)
+    ) %>%
+    dplyr::select(-feat_black_q, -feat_black_q_label)
+}
+
+factorize_race <- function(x) forcats::fct_relevel(factor(x), race_levels)
+
+theme_reach <- function(base_size = 12, base_family = NULL) {
+  ggplot2::theme_minimal(base_size = base_size, base_family = base_family) +
+    ggplot2::theme(
+      panel.grid.major = ggplot2::element_line(color = "#DFE2E5", linewidth = 0.4),
+      panel.grid.minor = ggplot2::element_blank(),
+      plot.title = ggplot2::element_text(face = "bold", size = base_size + 4, hjust = 0),
+      plot.subtitle = ggplot2::element_text(size = base_size + 0, margin = ggplot2::margin(b = 10)),
+      plot.caption = ggplot2::element_text(size = base_size - 2, color = "#5A5A5A", hjust = 0),
+      axis.text.x = ggplot2::element_text(angle = 45, hjust = 1),
+      legend.title = ggplot2::element_text(face = "bold"),
+      legend.position = "bottom",
+      plot.background = ggplot2::element_rect(fill = "white", color = NA),
+      panel.background = ggplot2::element_rect(fill = "white", color = NA),
+      plot.margin = ggplot2::margin(20, 30, 20, 20)
+    )
+}
+
+latest_year_available <- function(years) {
+  yrs <- sort(unique(as.character(years)))
+  if (length(yrs) == 0) NA_character_ else tail(yrs, 1)
+}
+
+write_description <- function(text, filename) {
+  full_path <- file.path(TEXT_DIR, filename)
+  dir.create(dirname(full_path), recursive = TRUE, showWarnings = FALSE)
+  writeLines(text, full_path, useBytes = TRUE)
+  invisible(full_path)
+}


### PR DESCRIPTION
## Summary
- add a dedicated `graph_scripts` folder with shared utilities for palettes, filtering, and description output
- script statewide and elementary race/ethnicity trend lines plus quartile comparison bar charts using the existing suspension data
- script an "unequal burden" concentration line chart to highlight the share of suspensions generated by the top 10% of schools

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8a50579608331a14edf2c63c29f8c