### PR TITLE
Add Python requirements for graph scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ renv::restore()
 
 `R/utils_keys_filters.R` defines `canon_race_label()` and `ALLOWED_RACES` used across analyses. The function maps CRDC code `RD` and strings such as "Not Reported" to the canonical label "Not Reported." This category is tracked for completeness but omitted from plots to avoid conflating missing data with student populations.
 
+## Python prerequisites for graph scripts
+
+Python utilities in `graph_scripts/` rely on a small set of data analysis libraries. Install them with:
+
+```bash
+pip install -r graph_scripts/requirements.txt
+```
+
 ## Analysis scripts
 
 The canonical analysis of Black student suspension rates by school racial composition lives at

--- a/graph_scripts/requirements.txt
+++ b/graph_scripts/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.26.4
+pandas==2.1.4
+pyarrow==15.0.2
+matplotlib==3.8.3


### PR DESCRIPTION
## Summary
- add a requirements file for the Python graph scripts with pinned data analysis dependencies
- document installing these requirements in the README so analysts can set up their environment

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8f140bbb883319bc40325393f498b