### PR TITLE
Label all statewide trend points

### DIFF
--- a/graph_scripts/06_statewide_trends.py
+++ b/graph_scripts/06_statewide_trends.py
@@ -218,7 +218,7 @@ def annotate_points(
     df: pd.DataFrame,
     color: str,
     offset: float,
-    label_last_only: bool = True,
+    label_last_only: bool = False,
 ) -> List[Annotation]:
     """Label data points while trying to reduce clutter on busy lines."""
 
@@ -263,7 +263,13 @@ def resolve_label_overlaps(ax: plt.Axes, annotations: Sequence[Annotation]) -> N
     if not annotations:
         return
 
+    if len(annotations) == 1:
+        annotations[0].set_visible(True)
+        return
+
     initial_positions = [getattr(annotation, "_initial_xytext", annotation.get_position()) for annotation in annotations]
+
+    max_iterations = max(50, min(180, len(annotations) * 5))
 
     adjust_text(
         annotations,
@@ -274,7 +280,7 @@ def resolve_label_overlaps(ax: plt.Axes, annotations: Sequence[Annotation]) -> N
         force_points=(0.05, 0.2),
         force_text=(0.1, 0.3),
         autoalign="y",
-        lim=200,
+        lim=max_iterations,
     )
 
     for annotation in annotations:
@@ -380,7 +386,13 @@ def build_level_figure(base: pd.DataFrame) -> Tuple[pd.DataFrame, List[str]]:
                 markeredgewidth=0.6,
             )
             axis_annotations.extend(
-                annotate_points(ax, race_df, RACE_PALETTE[race], offset)
+                annotate_points(
+                    ax,
+                    race_df,
+                    RACE_PALETTE[race],
+                    offset,
+                    label_last_only=False,
+                )
             )
             if race not in legend_handles:
                 legend_handles[race] = line
@@ -453,7 +465,13 @@ def build_locale_figure(base: pd.DataFrame) -> Tuple[pd.DataFrame, List[str]]:
                 markeredgewidth=0.6,
             )
             axis_annotations.extend(
-                annotate_points(ax, race_df, RACE_PALETTE[race], offset)
+                annotate_points(
+                    ax,
+                    race_df,
+                    RACE_PALETTE[race],
+                    offset,
+                    label_last_only=False,
+                )
             )
             if race not in legend_handles:
                 legend_handles[race] = line
@@ -538,7 +556,13 @@ def build_quartile_figure(base: pd.DataFrame) -> Tuple[pd.DataFrame, List[str]]:
                 markeredgewidth=0.6,
             )
             axis_annotations.extend(
-                annotate_points(ax, race_df, RACE_PALETTE[race], offset)
+                annotate_points(
+                    ax,
+                    race_df,
+                    RACE_PALETTE[race],
+                    offset,
+                    label_last_only=False,
+                )
             )
             if race not in legend_handles:
                 legend_handles[race] = line


### PR DESCRIPTION
## Summary
- default statewide trend point annotation helper to label every year by default
- ensure every figure requests full-series labels
- scale the overlap resolver for more annotations to keep performance predictable

## Testing
- python -m compileall graph_scripts/06_statewide_trends.py

------
https://chatgpt.com/codex/tasks/task_e_68c903840f448331a70eec0f5dfc8519