### PR TITLE
Add graph comparing suspension rates across enrollment quartiles

### DIFF
--- a/R/22_build_v6_features.R
+++ b/R/22_build_v6_features.R
@@ -105,25 +105,43 @@ if (REBUILD_V6 || !file.exists(V6_FEAT_PARQ)) {
       summarise(across(everything(), ~dplyr::first(na.omit(.))), .groups = "drop")
   }
   # Quartile label cleanup
+  quartile_levels <- c("Q1","Q2","Q3","Q4","Unknown")
+
   v5_feats <- v5_core %>%
     mutate(
-      black_prop_q = as.integer(black_prop_q),
+      across(c(black_prop_q, white_prop_q, hispanic_prop_q), as.integer),
       black_prop_q_label = case_when(
         !is.na(black_prop_q_label) ~ str_replace(as.character(black_prop_q_label), "\\s*\\(.*\\)$", ""),
         !is.na(black_prop_q)      ~ paste0("Q", black_prop_q),
         TRUE ~ "Unknown"
       ),
-      black_prop_q_label = factor(black_prop_q_label,
-                                  levels = c("Q1","Q2","Q3","Q4","Unknown"),
-                                  ordered = TRUE)
+      white_prop_q_label = case_when(
+        !is.na(white_prop_q_label) ~ str_replace(as.character(white_prop_q_label), "\\s*\\(.*\\)$", ""),
+        !is.na(white_prop_q)      ~ paste0("Q", white_prop_q),
+        TRUE ~ "Unknown"
+      ),
+      hispanic_prop_q_label = case_when(
+        !is.na(hispanic_prop_q_label) ~ str_replace(as.character(hispanic_prop_q_label), "\\s*\\(.*\\)$", ""),
+        !is.na(hispanic_prop_q)      ~ paste0("Q", hispanic_prop_q),
+        TRUE ~ "Unknown"
+      ),
+      black_prop_q_label = factor(black_prop_q_label, levels = quartile_levels, ordered = TRUE),
+      white_prop_q_label = factor(white_prop_q_label, levels = quartile_levels, ordered = TRUE),
+      hispanic_prop_q_label = factor(hispanic_prop_q_label, levels = quartile_levels, ordered = TRUE)
     ) %>%
     select(
       school_code,
       academic_year,
       dplyr::any_of("cds_school"),
       black_share = prop_black,
+      white_share = prop_white,
+      hispanic_share = prop_hispanic,
       black_prop_q,
+      white_prop_q,
+      hispanic_prop_q,
       black_prop_q_label,
+      white_prop_q_label,
+      hispanic_prop_q_label,
       school_type
     )
 

--- a/R/utils_keys_filters.R
+++ b/R/utils_keys_filters.R
@@ -271,7 +271,7 @@ ALLOWED_RACES <- c(
 
 ###############
 # construct standardized quartile labels like "Q1 (Lowest % Black)"
-get_quartile_label <- function(q4, race = c("Black", "White")) {
+get_quartile_label <- function(q4, race = c("Black", "White", "Hispanic/Latino")) {
   race <- match.arg(race)
   dplyr::case_when(
     is.na(q4) ~ "Unknown",


### PR DESCRIPTION
## Summary
- extend the shared graph utilities to expose standardized Black, White, and Hispanic/Latino quartile labels from the joined data
- add a reusable R script that aggregates multi-year suspension rates across all quartiles and races and saves a comparison plot plus a CSV export

## Testing
- `Rscript run_pipeline.R` *(fails: Rscript is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0be5a50083318519036570abf8ac