### PR TITLE
Add repelled labels to quartile comparison plot

### DIFF
--- a/graph_scripts/07_quartile_enrollment_comparison.R
+++ b/graph_scripts/07_quartile_enrollment_comparison.R
@@ -146,6 +146,18 @@ plot_rates <- ggplot(quartile_q4_rates,
                          group = subgroup)) +
   geom_line(linewidth = 0.7) +
   geom_point(size = 1.6) +
+  ggrepel::geom_label_repel(
+    aes(label = scales::percent(rate, accuracy = 0.1)),
+    size = 3,
+    label.size = 0,
+    label.padding = grid::unit(0.12, "lines"),
+    label.r = grid::unit(0.2, "lines"),
+    fill = "white",
+    box.padding = grid::unit(0.3, "lines"),
+    point.padding = grid::unit(0.3, "lines"),
+    min.segment.length = 0,
+    max.overlaps = Inf
+  ) +
 
   scale_color_manual(
     values = race_palette,


### PR DESCRIPTION
## Summary
- add repelled percentage labels to the quartile Q4 comparison plot to clarify point values
- configure label styling and padding to keep annotations readable across facets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb32ad7c0c8331aa6da2cbae98d3b9