### PR TITLE
Fix students suspended card zero display

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,7 +433,10 @@
         },
         {
           title: 'Students suspended',
-          value: totalStudentsSusp ? formatNumber(totalStudentsSusp, { maximumFractionDigits: 0 }) : '—',
+          value:
+            totalStudentsSusp != null
+              ? formatNumber(totalStudentsSusp, { maximumFractionDigits: 0 })
+              : '—',
           detail: studentRate != null ? `${formatNumber(studentRate)}% of students impacted.` : 'Share unavailable.',
         },
         {


### PR DESCRIPTION
## Summary
- ensure the "Students suspended" summary card formats zero counts via `formatNumber`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d32824665083318e58d48592717cc1