### PR TITLE
Stabilize suspension setting joins and quartile mappings

### DIFF
--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -54,15 +54,16 @@ features <- arrow::read_parquet(
     school_code,
     academic_year,
     is_traditional
-  ) %>%
-  mutate(
-    is_traditional = dplyr::coalesce(is_traditional, FALSE),
-    setting = if_else(is_traditional, "Traditional", "Non-traditional")
   )
 
 v6 <- v6 %>%
   left_join(features, by = c("school_code", "academic_year")) %>%
   mutate(
+    setting = case_when(
+      is_traditional ~ "Traditional",
+      is_traditional == FALSE ~ "Non-traditional",
+      TRUE ~ NA_character_
+    ),
     setting = factor(setting, levels = names(pal_setting)),
     across(ends_with("_prop_q_label"), ~ as.character(as.factor(.x)))
   ) %>%

--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -11,12 +11,27 @@ suppressPackageStartupMessages({
   library(ggrepel)
   library(scales)
   library(readr)
+  library(purrr)
 })
 
 try(here::i_am("Analysis/20_suspension_reason_trends_by_level_and_locale.R"), silent = TRUE)
 
 # canonical reason labels + palettes + locale levels
 source(here::here("R", "utils_keys_filters.R"))
+
+# palette for traditional vs. non-traditional comparisons
+pal_setting <- c(
+  "Traditional" = "#1f78b4",
+  "Non-traditional" = "#e31a1c"
+)
+
+# palette for enrollment quartiles
+pal_quartile <- c(
+  "Q1" = "#1b9e77",
+  "Q2" = "#d95f02",
+  "Q3" = "#7570b3",
+  "Q4" = "#e7298a"
+)
 
 # output directory
 out_dir <- here::here("outputs")
@@ -29,8 +44,29 @@ v6 <- arrow::read_parquet(
 ) %>%
   filter(
     category_type == "Race/Ethnicity",
-    subgroup == "All Students"
   )
+
+# bring in school setting (traditional vs. non-traditional) and race quartiles
+features <- arrow::read_parquet(
+  here::here("data-stage", "susp_v6_features.parquet")
+) %>%
+  select(
+    school_code,
+    academic_year,
+    is_traditional
+  ) %>%
+  mutate(
+    is_traditional = dplyr::coalesce(is_traditional, FALSE),
+    setting = if_else(is_traditional, "Traditional", "Non-traditional")
+  )
+
+v6 <- v6 %>%
+  left_join(features, by = c("school_code", "academic_year")) %>%
+  mutate(
+    setting = factor(setting, levels = names(pal_setting)),
+    across(ends_with("_prop_q_label"), ~ as.character(as.factor(.x)))
+  ) %>%
+  select(-is_traditional)
 
 # academic year order (lexical sort works for "2017-18" style)
 year_levels <- v6 %>%
@@ -39,6 +75,9 @@ year_levels <- v6 %>%
   pull(academic_year)
 v6 <- v6 %>%
   mutate(academic_year = factor(academic_year, levels = year_levels))
+
+v6_all <- v6 %>%
+  filter(subgroup == "All Students")
 
 # --- helpers ------------------------------------------------------------------
 # compute suspension reason rates for arbitrary grouping columns
@@ -150,7 +189,7 @@ plot_reason_area <- function(df, facet_col = NULL, title_txt) {
 
 # --- 3) Overall trends -------------------------------------------------------
 # Calculate overall statewide reason rates
-overall_rates <- summarise_reason_rates(v6, "academic_year") %>%
+overall_rates <- summarise_reason_rates(v6_all, "academic_year") %>%
   mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
 save_table(overall_rates, "20_overall_reason_rates.csv")
 
@@ -166,9 +205,40 @@ p_overall_reason <- plot_reason_area(overall_rates, NULL,
 ggsave(file.path(out_dir, "20_overall_reason_rates.png"), p_overall_reason,
        width = 10, height = 6, dpi = 300)
 
+# --- 3a) By school setting ---------------------------------------------------
+setting_rates <- summarise_reason_rates(
+  v6_all %>% filter(!is.na(setting)),
+  c("academic_year", "setting")
+) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
+save_table(setting_rates, "20_setting_reason_rates.csv")
+save_table(
+  distinct(setting_rates, academic_year, setting, total_rate),
+  "20_setting_total_rates.csv"
+)
+
+p_setting_total <- plot_total_rate(
+  distinct(setting_rates, academic_year, setting, total_rate),
+  "Suspension Rate by School Setting",
+  color_col = "setting",
+  palette = pal_setting
+)
+
+ggsave(file.path(out_dir, "20_setting_total_rate.png"), p_setting_total,
+       width = 10, height = 6, dpi = 300)
+
+p_setting_reason <- plot_reason_area(
+  setting_rates,
+  "setting",
+  "Suspension Reasons by School Setting"
+)
+
+ggsave(file.path(out_dir, "20_setting_reason_rates.png"), p_setting_reason,
+       width = 12, height = 8, dpi = 300)
+
 # --- 4) By grade level -------------------------------------------------------
 grade_levels <- LEVEL_LABELS[!LEVEL_LABELS %in% c("Other", "Alternative")]
-by_grade <- v6 %>%
+by_grade <- v6_all %>%
   filter(school_level %in% grade_levels) %>%
   mutate(school_level = factor(school_level, levels = grade_levels))
 
@@ -190,9 +260,53 @@ p_grade_reason <- plot_reason_area(grade_rates, "school_level",
 ggsave(file.path(out_dir, "20_grade_reason_rates.png"), p_grade_reason,
        width = 12, height = 8, dpi = 300)
 
+grade_setting_rates <- summarise_reason_rates(
+  by_grade %>% filter(!is.na(setting)),
+  c("academic_year", "school_level", "setting")
+) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
+save_table(grade_setting_rates, "20_grade_setting_reason_rates.csv")
+save_table(
+  distinct(grade_setting_rates, academic_year, school_level, setting, total_rate),
+  "20_grade_setting_total_rates.csv"
+)
+
+grade_setting_groups <- split(grade_setting_rates, grade_setting_rates$setting)
+purrr::walk(names(grade_setting_groups), function(setting_name) {
+  df <- grade_setting_groups[[setting_name]]
+  if (nrow(df) == 0) return(NULL)
+  title_suffix <- sprintf("— %s Schools", setting_name)
+  total_plot <- plot_total_rate(
+    distinct(df, academic_year, school_level, total_rate),
+    paste("Suspension Rate by Grade Level", title_suffix),
+    color_col = "school_level",
+    palette = pal_level[grade_levels]
+  )
+  ggsave(
+    file.path(out_dir, sprintf("20_grade_total_rate_%s.png", tolower(gsub("[^[:alnum:]]+", "_", setting_name)))),
+    total_plot,
+    width = 10,
+    height = 6,
+    dpi = 300
+  )
+
+  reason_plot <- plot_reason_area(
+    df,
+    "school_level",
+    paste("Suspension Reasons by Grade Level", title_suffix)
+  )
+  ggsave(
+    file.path(out_dir, sprintf("20_grade_reason_rates_%s.png", tolower(gsub("[^[:alnum:]]+", "_", setting_name)))),
+    reason_plot,
+    width = 12,
+    height = 8,
+    dpi = 300
+  )
+})
+
 # --- 5) By locale ------------------------------------------------------------
 loc_levels <- locale_levels[locale_levels != "Unknown"]
-by_locale <- v6 %>%
+by_locale <- v6_all %>%
   filter(locale_simple %in% loc_levels) %>%
   mutate(locale_simple = factor(locale_simple, levels = loc_levels))
 
@@ -213,6 +327,133 @@ p_locale_reason <- plot_reason_area(locale_rates, "locale_simple",
 
 ggsave(file.path(out_dir, "20_locale_reason_rates.png"), p_locale_reason,
        width = 12, height = 8, dpi = 300)
+
+locale_setting_rates <- summarise_reason_rates(
+  by_locale %>% filter(!is.na(setting)),
+  c("academic_year", "locale_simple", "setting")
+) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
+save_table(locale_setting_rates, "20_locale_setting_reason_rates.csv")
+save_table(
+  distinct(locale_setting_rates, academic_year, locale_simple, setting, total_rate),
+  "20_locale_setting_total_rates.csv"
+)
+
+locale_setting_groups <- split(locale_setting_rates, locale_setting_rates$setting)
+purrr::walk(names(locale_setting_groups), function(setting_name) {
+  df <- locale_setting_groups[[setting_name]]
+  if (nrow(df) == 0) return(NULL)
+  title_suffix <- sprintf("— %s Schools", setting_name)
+  total_plot <- plot_total_rate(
+    distinct(df, academic_year, locale_simple, total_rate),
+    paste("Suspension Rate by Locale", title_suffix),
+    color_col = "locale_simple",
+    palette = pal_locale[loc_levels]
+  )
+  ggsave(
+    file.path(out_dir, sprintf("20_locale_total_rate_%s.png", tolower(gsub("[^[:alnum:]]+", "_", setting_name)))),
+    total_plot,
+    width = 10,
+    height = 6,
+    dpi = 300
+  )
+
+  reason_plot <- plot_reason_area(
+    df,
+    "locale_simple",
+    paste("Suspension Reasons by Locale", title_suffix)
+  )
+  ggsave(
+    file.path(out_dir, sprintf("20_locale_reason_rates_%s.png", tolower(gsub("[^[:alnum:]]+", "_", setting_name)))),
+    reason_plot,
+    width = 12,
+    height = 8,
+    dpi = 300
+  )
+})
+
+# --- 6) Reason trends by race quartile ---------------------------------------
+quartile_levels <- names(pal_quartile)
+race_quartile_map <- tibble::tibble(
+  subgroup = c("Black/African American", "Hispanic/Latino", "White"),
+  quartile_col = c("black_prop_q_label", "hispanic_prop_q_label", "white_prop_q_label")
+)
+
+race_quartile_data <- v6 %>%
+  filter(subgroup %in% race_quartile_map$subgroup) %>%
+  left_join(race_quartile_map, by = "subgroup") %>%
+  rowwise() %>%
+  mutate(
+    enrollment_quartile = .data[[quartile_col]]
+  ) %>%
+  ungroup() %>%
+  mutate(
+    enrollment_quartile = factor(as.character(enrollment_quartile), levels = quartile_levels),
+    setting = factor(setting, levels = names(pal_setting))
+  ) %>%
+  filter(!is.na(enrollment_quartile), !is.na(setting))
+
+quartile_rates <- summarise_reason_rates(
+  race_quartile_data,
+  c("academic_year", "subgroup", "setting", "enrollment_quartile")
+) %>%
+  mutate(reason_lab = factor(reason_lab, levels = names(pal_reason)))
+
+save_table(quartile_rates, "20_race_quartile_reason_rates.csv")
+
+quartile_total_rates <- quartile_rates %>%
+  distinct(academic_year, subgroup, setting, enrollment_quartile, total_rate)
+save_table(quartile_total_rates, "20_race_quartile_total_rates.csv")
+
+p_quartile_total <- ggplot(quartile_total_rates,
+                           aes(x = academic_year, y = total_rate,
+                               color = enrollment_quartile,
+                               group = enrollment_quartile)) +
+  geom_line(linewidth = 1.1) +
+  geom_point(size = 2.5) +
+  scale_color_manual(values = pal_quartile, drop = FALSE) +
+  scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
+  facet_grid(setting ~ subgroup) +
+  labs(
+    title = "Suspension Rates by Enrollment Quartile and Race/Ethnicity",
+    x = "Academic Year",
+    y = "Suspension Rate",
+    color = "Enrollment Quartile"
+  ) +
+  theme_minimal(base_size = 14) +
+  theme(
+    axis.text.x = element_text(angle = 45, hjust = 1),
+    plot.title = element_text(face = "bold")
+  )
+
+ggsave(file.path(out_dir, "20_race_quartile_total_rates.png"), p_quartile_total,
+       width = 14, height = 8, dpi = 300)
+
+quartile_plot_groups <- quartile_rates %>% distinct(setting, subgroup)
+purrr::pwalk(quartile_plot_groups, function(setting, subgroup) {
+  df <- quartile_rates %>%
+    filter(setting == !!setting, subgroup == !!subgroup)
+  if (nrow(df) == 0) return(NULL)
+  title_txt <- sprintf(
+    "Suspension Reasons by Enrollment Quartile — %s (%s)",
+    subgroup,
+    setting
+  )
+  reason_plot <- plot_reason_area(
+    df,
+    "enrollment_quartile",
+    title_txt
+  )
+  file_stub <- paste(setting, subgroup)
+  file_stub <- tolower(gsub("[^[:alnum:]]+", "_", file_stub))
+  ggsave(
+    file.path(out_dir, sprintf("20_race_quartile_reason_rates_%s.png", file_stub)),
+    reason_plot,
+    width = 12,
+    height = 8,
+    dpi = 300
+  )
+})
 
 message("Analysis complete. Tables and graphics saved to: ", out_dir)
 


### PR DESCRIPTION
## Summary
- ensure traditional vs. non-traditional flags are merged without duplicating quartile columns and normalize quartile labels for downstream use
- exclude campuses without a known setting from setting-dependent summaries so grouped exports and plots only include classified schools
- resolve race-specific enrollment quartile mapping by selecting the appropriate quartile label per subgroup before calculating trends

## Testing
- ⚠️ `Rscript Analysis/20_suspension_reason_trends_by_level_and_locale.R` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46fc9f5b48331a135e9a01267ef47