### PR TITLE
Gracefully handle empty suspension reason plots

### DIFF
--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -69,12 +69,23 @@ features <- arrow::read_parquet(
 v6 <- v6 %>%
   left_join(features, by = c("school_code", "academic_year")) %>%
   mutate(
-
-    setting = factor(setting, levels = names(pal_setting)),
     across(ends_with("_prop_q_label"), ~ as.character(.x))
-
   ) %>%
   select(-is_traditional)
+
+valid_settings <- sort(unique(stats::na.omit(v6$setting)))
+unexpected_settings <- setdiff(valid_settings, names(pal_setting))
+if (length(unexpected_settings) > 0) {
+  stop(
+    sprintf(
+      "Unexpected school setting values: %s",
+      paste(unexpected_settings, collapse = ", ")
+    )
+  )
+}
+
+v6 <- v6 %>%
+  mutate(setting = factor(as.character(setting), levels = names(pal_setting)))
 
 # academic year order (lexical sort works for "2017-18" style)
 year_levels <- v6 %>%
@@ -112,7 +123,7 @@ summarise_reason_rates <- function(df, group_cols) {
     ) %>%
     add_reason_label("reason") %>%
     mutate(
-      reason_lab = factor(reason_lab, levels = names(pal_reason)),
+      reason_lab = factor(as.character(reason_lab), levels = names(pal_reason)),
       reason_rate = if_else(enrollment > 0, count / enrollment, NA_real_)
     )
 }
@@ -142,7 +153,12 @@ plot_total_rate <- function(df, title_txt, color_col = NULL, palette = NULL) {
 
   if (!is.null(color_col)) {
     if (!is.null(palette)) {
-      p <- p + scale_color_manual(values = palette)
+      p <- p + scale_color_manual(
+        values = palette,
+        breaks = names(palette),
+        limits = names(palette),
+        drop = FALSE
+      )
     } else {
       p <- p + scale_color_discrete()
     }
@@ -156,6 +172,19 @@ plot_total_rate <- function(df, title_txt, color_col = NULL, palette = NULL) {
 }
 
 plot_reason_area <- function(df, facet_col = NULL, title_txt) {
+  df <- df %>% filter(!is.na(reason_lab))
+
+  if (nrow(df) == 0) {
+    warning("No data available to plot for the requested grouping; returning placeholder plot.")
+    return(
+      ggplot() +
+        annotate("text", x = 0.5, y = 0.5, label = "No data available", fontface = "bold") +
+        labs(title = title_txt, x = NULL, y = NULL) +
+        theme_void() +
+        theme(plot.title = element_text(face = "bold", hjust = 0.5))
+    )
+  }
+
   if (is.null(facet_col)) {
     labels <- df %>% group_by(academic_year) %>%
       summarise(total_rate = first(total_rate), .groups = "drop")
@@ -166,6 +195,7 @@ plot_reason_area <- function(df, facet_col = NULL, title_txt) {
                 vjust = -0.5, fontface = "bold", inherit.aes = FALSE) +
       scale_fill_manual(values = pal_reason,
                         breaks = names(pal_reason),
+                        limits = names(pal_reason),
                         name = "Reason for Suspension",
                         drop = FALSE) +
       scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +
@@ -185,6 +215,7 @@ plot_reason_area <- function(df, facet_col = NULL, title_txt) {
       facet_wrap(as.formula(paste0("~", facet_col)), ncol = 2) +
       scale_fill_manual(values = pal_reason,
                         breaks = names(pal_reason),
+                        limits = names(pal_reason),
                         name = "Reason for Suspension",
                         drop = FALSE) +
       scale_y_continuous(labels = percent_format(accuracy = 1), limits = c(0, NA)) +


### PR DESCRIPTION
## Summary
- return a placeholder plot instead of stopping when no suspension-reason data are available for a grouping
- add a descriptive warning so RStudio users know why a placeholder figure appears

## Testing
- ⚠️ `Rscript Analysis/20_suspension_reason_trends_by_level_and_locale.R` *(cannot run because R is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4822fe0448331ac625f372dae9d57