### PR TITLE
Fix school setting classification in suspension trends

### DIFF
--- a/Analysis/20_suspension_reason_trends_by_level_and_locale.R
+++ b/Analysis/20_suspension_reason_trends_by_level_and_locale.R
@@ -58,9 +58,9 @@ features <- arrow::read_parquet(
   ) %>%
   mutate(
     setting = case_when(
-      isTRUE(is_traditional)  ~ "Traditional",
-      isFALSE(is_traditional) ~ "Non-traditional",
-      TRUE                    ~ NA_character_
+      is_traditional %in% TRUE  ~ "Traditional",
+      is_traditional %in% FALSE ~ "Non-traditional",
+      TRUE                      ~ NA_character_
     )
   )
 


### PR DESCRIPTION
## Summary
- ensure school setting labels are derived with vectorised logic instead of non-vectorised isTRUE/isFALSE checks
- allow suspension trend tables and plots grouped by setting to populate with actual data

## Testing
- Rscript Analysis/20_suspension_reason_trends_by_level_and_locale.R *(fails: Rscript not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d54215d8048331b0dc3bbe06b39efa