### PR TITLE
Update tail concentration dashboard with UCLA colors

### DIFF
--- a/tail_concentration_dashboard.html
+++ b/tail_concentration_dashboard.html
@@ -12,12 +12,15 @@
     :root {
       color-scheme: light;
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      --bg: #f5f6fa;
+      --bg: #daebfe;
       --card-bg: #ffffff;
-      --border: #d9dde7;
-      --text: #1f2933;
-      --muted: #5f6b7c;
-      --accent: #4361ee;
+      --border: #8bb8e8;
+      --text: #003b5c;
+      --muted: rgba(0, 59, 92, 0.8);
+      --accent: #2774ae;
+      --accent-strong: #005587;
+      --accent-soft: #8bb8e8;
+      --highlight: #ffb81c;
     }
 
     body {
@@ -28,10 +31,10 @@
     }
 
     header {
-      background: #10172a;
-      color: white;
+      background: var(--accent-strong);
+      color: #ffffff;
       padding: 2.5rem 1.5rem 2rem;
-      box-shadow: 0 4px 18px rgba(16, 23, 42, 0.25);
+      box-shadow: 0 4px 18px rgba(0, 59, 92, 0.35);
     }
 
     header h1 {
@@ -44,7 +47,7 @@
       margin: 0.75rem 0 0;
       max-width: 60rem;
       font-size: 1rem;
-      color: rgba(255, 255, 255, 0.82);
+      color: rgba(218, 235, 254, 0.85);
     }
 
     main {
@@ -59,7 +62,7 @@
       border-radius: 16px;
       padding: 1.5rem;
       margin-bottom: 1.5rem;
-      box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
+      box-shadow: 0 10px 22px rgba(0, 59, 92, 0.1);
     }
 
     h2 {
@@ -99,14 +102,14 @@
       padding: 0.55rem 0.75rem;
       font-size: 0.95rem;
       font-family: inherit;
-      background: #fff;
+      background: var(--card-bg);
       color: var(--text);
       outline: none;
     }
 
     select:focus {
       border-color: var(--accent);
-      box-shadow: 0 0 0 3px rgba(67, 97, 238, 0.15);
+      box-shadow: 0 0 0 3px rgba(39, 116, 174, 0.3);
     }
 
     .note {
@@ -128,8 +131,8 @@
     }
 
     thead {
-      background: #eef2ff;
-      color: #1d2a5c;
+      background: var(--accent-soft);
+      color: var(--text);
     }
 
     th, td {
@@ -144,7 +147,7 @@
 
     .empty {
       padding: 1rem;
-      background: #f8fafc;
+      background: rgba(218, 235, 254, 0.75);
       border-radius: 12px;
       border: 1px dashed var(--border);
       text-align: center;
@@ -174,16 +177,18 @@
     button.reset {
       margin-top: 0.75rem;
       border-radius: 999px;
-      background: #e6ecff;
-      color: #1f3a8a;
+      background: var(--accent-soft);
+      color: var(--text);
       border: none;
       padding: 0.5rem 1rem;
       font-weight: 600;
       cursor: pointer;
+      transition: background-color 0.2s ease, color 0.2s ease;
     }
 
     button.reset:hover {
-      background: #d9e2ff;
+      background: var(--accent);
+      color: #ffffff;
     }
 
     #loading {
@@ -458,6 +463,7 @@
       }
 
       const groups = Array.from(new Set(rows.map((row) => row.student_group))).sort();
+      const palette = ['#005587', '#2774ae', '#ffb81c'];
       const traces = thresholds.map((thr, idx) => ({
         type: 'bar',
         name: `Top ${Math.round(thr * 100)}%`,
@@ -466,7 +472,7 @@
           const match = rows.find((row) => row.student_group === group && row.threshold === thr);
           return match && match.share != null ? Number((match.share * 100).toFixed(1)) : null;
         }),
-        marker: { color: ['#2563eb', '#7c3aed', '#0f766e'][idx % 3] },
+        marker: { color: palette[idx % palette.length] },
       }));
 
       Plotly.newPlot('tail-chart', traces, {


### PR DESCRIPTION
## Summary
- replace the dashboard CSS tokens, layout surfaces, and interactive states with UCLA brand blues and highlight tones for consistent contrast
- align the Plotly bar palette with the approved UCLA colorway so charts match the refreshed interface

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d5a41ad4b883318414282ec7986082