### PR TITLE
Add tail concentration dashboard link on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,30 @@
 
     .filters { display: grid; gap: 1.5rem; }
 
+    .cta-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 1rem;
+    }
+
+    .cta-button {
+      display: inline-block;
+      padding: 0.6rem 1.2rem;
+      background: var(--primary);
+      color: #fff;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .cta-button:focus,
+    .cta-button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 18px rgba(39, 116, 174, 0.3);
+    }
+
     .filter-group {
       display: flex;
       flex-wrap: wrap;
@@ -213,14 +237,14 @@
 
   <main>
     <section class="panel intro">
-      <p>
-  <a href="suspension_dashboard.html" 
-     style="display:inline-block; margin-top:1rem; padding:0.6rem 1.2rem; 
-            background:#2774ae; color:white; border-radius:8px; 
-            text-decoration:none; font-weight:600;">
-    View Suspension Dashboard
-  </a>
-</p>
+      <div class="cta-links">
+        <a class="cta-button" href="suspension_dashboard.html">
+          View Suspension Dashboard
+        </a>
+        <a class="cta-button" href="tail_concentration_dashboard.html">
+          View Tail Concentration Dashboard
+        </a>
+      </div>
       <h2>Why this dashboard matters</h2>
       <p>
         This interactive view distills the REACH suspension dataset to highlight the systemic patterns that shape students' experiences.


### PR DESCRIPTION
## Summary
- add shared call-to-action styling for landing page dashboard links
- include Tail Concentration Dashboard link alongside existing Suspension Dashboard button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a52339bc8331a6ad09708467a58a