### PR TITLE
Apply UCLA colors to suspension share bars

### DIFF
--- a/tail_concentration_dashboard.html
+++ b/tail_concentration_dashboard.html
@@ -772,6 +772,10 @@
         soft: getComputedStyle(document.documentElement).getPropertyValue('--accent-soft').trim() || '#8bb8e8',
       };
 
+      const uclaSuspensionColors = ['#2774AE', '#FFB81C', '#8BB8E8', '#005587', '#FFC72C'];
+      const suspensionColors = labels.map((_, index) => uclaSuspensionColors[index % uclaSuspensionColors.length]);
+      const suspensionHoverColors = suspensionColors.slice();
+
       const topShareContext = document.getElementById('top-share-chart').getContext('2d');
       const topShareConfig = {
         type: 'bar',
@@ -781,8 +785,8 @@
             {
               label: 'Suspension share',
               data: suspensionShare,
-              backgroundColor: palette.primary,
-              hoverBackgroundColor: palette.highlight,
+              backgroundColor: suspensionColors,
+              hoverBackgroundColor: suspensionHoverColors,
               borderRadius: 8,
               borderSkipped: false,
             },
@@ -821,6 +825,8 @@
       if (charts.topShare) {
         charts.topShare.data.labels = labels;
         charts.topShare.data.datasets[0].data = suspensionShare;
+        charts.topShare.data.datasets[0].backgroundColor = suspensionColors;
+        charts.topShare.data.datasets[0].hoverBackgroundColor = suspensionHoverColors;
         charts.topShare.update();
       } else {
         charts.topShare = new Chart(topShareContext, topShareConfig);


### PR DESCRIPTION
## Summary
- add a UCLA brand color array for the suspension share chart
- map sorted percentile labels to branded bar and hover colors
- update existing chart instances with the new color assignments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5ce26748483318dbdaa3ec4e877ca