### PR TITLE
Allow table to load after update analysis

### DIFF
--- a/race_year_rates_dashboard.html
+++ b/race_year_rates_dashboard.html
@@ -418,20 +418,67 @@
         const scriptSelector = 'script[data-rates-bundle]';
         let script = document.querySelector(scriptSelector);
 
-        const handleLoad = () => {
+        const resolveWithPayload = () => {
           const payload = getPreloadedData();
           if (payload) {
             resolve(payload);
           } else {
+            if (script && script.dataset) {
+              script.dataset.ratesBundleState = 'error';
+            }
             reject(new Error('Bundle loaded but data missing'));
           }
         };
 
+        const handleLoad = () => {
+          if (script && script.dataset) {
+            script.dataset.ratesBundleState = 'loaded';
+          }
+          resolveWithPayload();
+        };
+
         const handleError = () => {
+          if (script && script.dataset) {
+            script.dataset.ratesBundleState = 'error';
+          }
           reject(new Error('Failed to load precomputed data bundle'));
         };
 
+        const handleExistingScriptState = () => {
+          if (!script) {
+            return false;
+          }
+          const state = script.dataset ? script.dataset.ratesBundleState : undefined;
+          if (state === 'loaded') {
+            resolveWithPayload();
+            return true;
+          }
+          if (state === 'error') {
+            reject(new Error('Failed to load precomputed data bundle'));
+            return true;
+          }
+          const readyState = script.readyState;
+          if (readyState === 'complete' || readyState === 'loaded') {
+            if (script.dataset) {
+              script.dataset.ratesBundleState = 'loaded';
+            }
+            resolveWithPayload();
+            return true;
+          }
+          if (readyState === 'error') {
+            if (script.dataset) {
+              script.dataset.ratesBundleState = 'error';
+            }
+            reject(new Error('Failed to load precomputed data bundle'));
+            return true;
+          }
+          return false;
+        };
+
         if (script) {
+          if (handleExistingScriptState()) {
+            return;
+          }
           script.addEventListener('load', handleLoad, { once: true });
           script.addEventListener('error', handleError, { once: true });
           return;
@@ -440,6 +487,9 @@
         script = document.createElement('script');
         script.src = DATA_BUNDLE_SRC;
         script.dataset.ratesBundle = 'true';
+        if (script.dataset) {
+          script.dataset.ratesBundleState = 'pending';
+        }
         script.addEventListener('load', handleLoad, { once: true });
         script.addEventListener('error', handleError, { once: true });
         document.head.appendChild(script);
@@ -636,14 +686,6 @@
       ));
     }
 
-    function hasAllSelections({ years, races, levels, settings, includeAllLevels, includeAllSettings }) {
-      const allYears = years.length === state.years.length;
-      const allRaces = races.length === state.races.length;
-      const allLevels = includeAllLevels || levels.length === state.levels.length;
-      const allSettings = includeAllSettings || settings.length === state.settings.length;
-      return allYears && allRaces && allLevels && allSettings;
-    }
-
     function updateSummary(filtered) {
       const totalSchools = filtered.reduce((sum, row) => sum + Number(row.n_schools || 0), 0);
       const totalRecords = filtered.reduce((sum, row) => sum + Number(row.n_records || 0), 0);
@@ -673,14 +715,11 @@
     function renderTable(filtered) {
       const wrapper = document.getElementById('table-wrapper');
       wrapper.innerHTML = '';
-      const allSelected = hasAllSelections(state.selections);
 
-      if (!state.tableUnlocked || !allSelected) {
+      if (!state.tableUnlocked) {
         const guidance = document.createElement('div');
         guidance.className = 'empty-state';
-        guidance.innerHTML = state.tableUnlocked
-          ? 'Full race × year details appear when every filter option is selected.'
-          : 'Select every filter option and press <strong>Update analysis</strong> to load the full race × year table.';
+        guidance.innerHTML = 'Choose any combination of filters and press <strong>Update analysis</strong> to load the race × year table.';
         wrapper.appendChild(guidance);
         return;
       }
@@ -688,7 +727,7 @@
       if (filtered.length === 0) {
         const empty = document.createElement('div');
         empty.className = 'empty-state';
-        empty.textContent = 'No data available for the current selection.';
+        empty.textContent = 'No data available for the current selection. Adjust your filters and press Update analysis to try again.';
         wrapper.appendChild(empty);
         return;
       }
@@ -964,10 +1003,9 @@
       const selections = getSelections();
       state.selections = selections;
       const filtered = filterData(selections);
-      const allSelected = hasAllSelections(selections);
 
       if (allowTableUnlock) {
-        state.tableUnlocked = allSelected;
+        state.tableUnlocked = true;
       }
 
       updateSummary(filtered);


### PR DESCRIPTION
## Summary
- remove the all-filters requirement before rendering the race × year table
- keep the table gated behind the Update analysis button and refresh messaging for empty selections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69120abe083318b1c2e057256a6c0