### PR TITLE
Align index landing page styling with dashboard theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,15 +9,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
   <style>
     :root {
-      --bg: #daebfe;
-      --surface: #ffffff;
-      --border: #8bb8e8;
       --primary: #2774ae;
-      --accent: #ffb81c;
+      --primary-dark: #003b5c;
+      --accent: #ffd100;
+      --accent-warm: #ffc72c;
+      --surface: rgba(255, 255, 255, 0.95);
+      --text: #003b5c;
       --muted: #005587;
-      --success: #003b5c;
-      --warning: #ffc72c;
-      --danger: #005587;
+      --shadow: 0 8px 32px rgba(0, 59, 92, 0.1);
     }
 
     * { box-sizing: border-box; }
@@ -25,53 +24,62 @@
     body {
       margin: 0;
       font-family: 'Inter', sans-serif;
-      background: var(--bg);
-      color: #003b5c;
+      background: linear-gradient(135deg, #003b5c 0%, #2774ae 100%);
+      color: var(--text);
       line-height: 1.6;
+      min-height: 100vh;
     }
 
     header {
-      background: linear-gradient(135deg, var(--primary), #003b5c);
-      color: #fff;
-      padding: 3.5rem 1.5rem 2.5rem;
+      background: var(--surface);
+      padding: 2.75rem 1.5rem 2.25rem;
       text-align: center;
-      box-shadow: 0 10px 25px rgba(0, 59, 92, 0.25);
+      box-shadow: 0 4px 20px rgba(0, 59, 92, 0.12);
+      margin-bottom: 2.5rem;
     }
 
     header h1 {
       margin: 0;
-      font-size: 2.6rem;
+      font-size: 2.5rem;
       letter-spacing: 0.02em;
       font-weight: 700;
+      color: var(--primary-dark);
     }
 
     header p {
       margin: 0.75rem auto 0;
       max-width: 760px;
       font-size: 1.05rem;
-      color: rgba(255, 255, 255, 0.9);
+      color: var(--primary);
     }
 
     main {
       max-width: 1200px;
-      margin: -2rem auto 4rem;
+      margin: 0 auto 4rem;
       padding: 0 1.5rem;
     }
 
     section { margin-top: 2rem; }
 
+    section.panel:first-of-type {
+      margin-top: 0;
+    }
+
     .panel {
       background: var(--surface);
-      border-radius: 16px;
-      padding: 1.75rem;
-      box-shadow: 0 12px 30px rgba(0, 59, 92, 0.12);
-      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 2rem;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(6px);
     }
 
     h2 {
       font-size: 1.5rem;
       margin-bottom: 1rem;
-      color: var(--primary);
+      color: var(--primary-dark);
+      border-bottom: 3px solid var(--accent);
+      display: inline-block;
+      padding-bottom: 0.35rem;
     }
 
     h3 {
@@ -90,23 +98,24 @@
       flex-wrap: wrap;
       gap: 0.75rem;
       margin-top: 1rem;
+      justify-content: center;
     }
 
     .cta-button {
       display: inline-block;
-      padding: 0.6rem 1.2rem;
-      background: var(--primary);
-      color: #fff;
+      padding: 0.7rem 1.4rem;
+      background: linear-gradient(90deg, var(--accent), var(--accent-warm));
+      color: var(--primary-dark);
       border-radius: 8px;
       text-decoration: none;
-      font-weight: 600;
+      font-weight: 700;
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
     .cta-button:focus,
     .cta-button:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 6px 18px rgba(39, 116, 174, 0.3);
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(0, 59, 92, 0.18);
     }
 
     .filter-group {
@@ -123,12 +132,12 @@
     }
 
     .option-pill {
-      border: 1px solid var(--border);
-      padding: 0.35rem 0.75rem;
+      border: 1px solid rgba(39, 116, 174, 0.3);
+      padding: 0.45rem 0.85rem;
       border-radius: 999px;
-      background: #fff;
+      background: rgba(255, 255, 255, 0.9);
       cursor: pointer;
-      font-size: 0.9rem;
+      font-size: 0.92rem;
       color: var(--muted);
       transition: all 0.2s ease;
     }
@@ -136,10 +145,10 @@
     .option-pill input { display: none; }
 
     .option-pill.active {
-      background: rgba(39, 116, 174, 0.16);
-      color: var(--primary);
+      background: linear-gradient(135deg, rgba(139, 184, 232, 0.35), rgba(218, 235, 254, 0.8));
+      color: var(--primary-dark);
       border-color: var(--primary);
-      font-weight: 600;
+      font-weight: 700;
     }
 
     .summary-grid {
@@ -150,25 +159,24 @@
     }
 
     .summary-card {
-      background: linear-gradient(145deg, rgba(39, 116, 174, 0.12), rgba(255, 255, 255, 0.95));
-      border-radius: 14px;
-      padding: 1.25rem 1.5rem;
-      border: 1px solid rgba(39, 116, 174, 0.18);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+      background: linear-gradient(135deg, #8bb8e8 0%, #daebfe 100%);
+      border-radius: 10px;
+      padding: 1.5rem 1.7rem;
+      box-shadow: 0 6px 20px rgba(0, 59, 92, 0.12);
     }
 
     .summary-card h4 {
       margin: 0;
       font-size: 0.95rem;
       font-weight: 600;
-      color: var(--muted);
+      color: var(--primary-dark);
     }
 
     .summary-card p {
       margin: 0.4rem 0 0;
       font-size: 1.9rem;
       font-weight: 700;
-      color: var(--primary);
+      color: var(--primary-dark);
     }
 
     .summary-card span {
@@ -182,8 +190,21 @@
 
     .chart { min-height: 360px; }
 
-    .narrative { display: grid; gap: 1rem; color: var(--muted); }
-    .narrative strong { color: var(--primary); }
+    .narrative {
+      display: grid;
+      gap: 1rem;
+      color: var(--muted);
+      background: rgba(218, 235, 254, 0.3);
+      border-left: 5px solid var(--accent);
+      padding: 1.1rem 1.25rem;
+      border-radius: 0 10px 10px 0;
+    }
+    .narrative strong {
+      color: var(--primary-dark);
+      background: linear-gradient(90deg, var(--accent), var(--accent-warm));
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+    }
 
     .definition-list {
       display: grid;
@@ -193,10 +214,19 @@
       color: var(--muted);
     }
 
+    .definition-list li {
+      list-style: disc;
+      background: rgba(218, 235, 254, 0.35);
+      border-left: 5px solid var(--accent);
+      padding: 0.75rem 1rem;
+      border-radius: 0 10px 10px 0;
+      color: var(--muted);
+    }
+
     .footer-note {
       margin-top: 1.5rem;
       font-size: 0.85rem;
-      color: var(--muted);
+      color: rgba(0, 85, 135, 0.85);
     }
 
     .toggle-row {
@@ -208,19 +238,37 @@
       font-size: 0.9rem;
     }
 
-    select, button {
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 0.35rem 0.5rem;
-      background: #fff;
+    .toggle-row label,
+    .toggle-row span {
       color: var(--muted);
+    }
+
+    .toggle-row input {
+      margin-right: 0.35rem;
+    }
+
+    select, button {
+      border: 2px solid rgba(139, 184, 232, 0.8);
+      border-radius: 8px;
+      padding: 0.55rem 0.75rem;
+      background: rgba(255, 255, 255, 0.95);
+      color: var(--primary-dark);
       cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    select:focus, button:focus {
+      outline: none;
+      border-color: var(--primary);
+      box-shadow: 0 0 0 3px rgba(39, 116, 174, 0.18);
     }
 
     @media (max-width: 768px) {
-      header { padding: 2.5rem 1rem 2rem; }
-      header h1 { font-size: 2.1rem; }
-
+      header { padding: 2.3rem 1.25rem 1.8rem; margin-bottom: 2rem; }
+      header h1 { font-size: 2.2rem; }
+      main { padding: 0 1.25rem; }
+      .panel { padding: 1.6rem; }
+      .cta-links { justify-content: center; }
       .filter-group { flex-direction: column; align-items: stretch; }
       .filter-group label.title { min-width: auto; }
     }


### PR DESCRIPTION
## Summary
- restyle the index landing page with the gradient background, semi-transparent panels, and typography used on the suspension dashboard
- refresh CTA buttons, filter pills, summary cards, and narrative callouts with UCLA accent gradients for a cohesive visual language
- tune spacing, focus styles, and responsive tweaks to keep the page polished across breakpoints

## Testing
- Not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d6cb54f9b48331b38b525e11d6129d