### PR TITLE
Align dashboard headers and gradients

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,21 +24,30 @@
     body {
       margin: 0;
       font-family: 'Inter', sans-serif;
-      background: linear-gradient(135deg, #003b5c 0%, #2774ae 100%);
+      background: linear-gradient(135deg, #003B5C 0%, #2774AE 100%);
       color: var(--text);
       line-height: 1.6;
       min-height: 100vh;
     }
 
-    header {
-      background: var(--surface);
-      padding: 2.75rem 1.5rem 2.25rem;
-      text-align: center;
+    .header {
+      background: rgba(255, 255, 255, 0.95);
+      padding: 2.75rem 0 2.25rem;
       box-shadow: 0 4px 20px rgba(0, 59, 92, 0.12);
       margin-bottom: 2.5rem;
     }
 
-    header h1 {
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .header .container {
+      text-align: center;
+    }
+
+    .header h1 {
       margin: 0;
       font-size: 2.5rem;
       letter-spacing: 0.02em;
@@ -46,7 +55,7 @@
       color: var(--primary-dark);
     }
 
-    header p {
+    .header p {
       margin: 0.75rem auto 0;
       max-width: 760px;
       font-size: 1.05rem;
@@ -275,12 +284,14 @@
   </style>
 </head>
 <body>
-  <header>
-    <h1>REACH Suspension Insights Dashboard</h1>
-    <p>
-      Explore California school suspension patterns through an equity lens. Filter the data to surface disparities by student group,
-      school setting, and the racial composition of campuses to guide strategic interventions.
-    </p>
+  <header class="header">
+    <div class="container">
+      <h1>REACH Suspension Insights Dashboard</h1>
+      <p>
+        Explore California school suspension patterns through an equity lens. Filter the data to surface disparities by student
+        group, school setting, and the racial composition of campuses to guide strategic interventions.
+      </p>
+    </div>
   </header>
 
   <main>

--- a/quartile_suspension_dashboard.html
+++ b/quartile_suspension_dashboard.html
@@ -26,62 +26,75 @@
     body {
       margin: 0;
       font-family: 'Inter', sans-serif;
-      background: linear-gradient(135deg, #003b5c 0%, #2774ae 100%);
+      background: linear-gradient(135deg, #003B5C 0%, #2774AE 100%);
       color: var(--deep);
       min-height: 100vh;
     }
 
-    .top-nav {
-      padding: 1rem 2rem 0;
-      text-align: right;
+    .header {
+      background: rgba(255, 255, 255, 0.95);
+      padding: 2.5rem 0;
+      box-shadow: 0 4px 20px rgba(0, 59, 92, 0.12);
+      margin-bottom: 2.5rem;
     }
 
-    .top-nav a,
-    .top-nav button {
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .header-top {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .nav-link {
       display: inline-flex;
       align-items: center;
       gap: 0.35rem;
-      background: rgba(255, 255, 255, 0.85);
+      background: rgba(39, 116, 174, 0.12);
       color: var(--deep);
       text-decoration: none;
       border-radius: 999px;
-      padding: 0.45rem 1.1rem;
+      padding: 0.5rem 1.2rem;
       font-weight: 600;
-      border: 1px solid rgba(255, 255, 255, 0.6);
-      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      border: 1px solid rgba(39, 116, 174, 0.2);
+      box-shadow: 0 8px 20px rgba(0, 59, 92, 0.08);
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
     }
 
-    .top-nav a:hover,
-    .top-nav a:focus {
+    .nav-link:hover,
+    .nav-link:focus-visible {
       transform: translateY(-1px);
-      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.12);
+      box-shadow: 0 10px 28px rgba(0, 59, 92, 0.12);
+      background: rgba(39, 116, 174, 0.2);
+      outline: none;
     }
 
-    header {
-      text-align: center;
-      color: white;
-      padding: 3rem 1.5rem 2.5rem;
-    }
-
-    header h1 {
+    .header h1 {
       font-size: 2.5rem;
       font-weight: 700;
       margin-bottom: 0.75rem;
       letter-spacing: 0.01em;
+      color: #003B5C;
+      text-align: center;
     }
 
-    header p {
+    .header p {
       max-width: 820px;
       margin: 0 auto;
       font-size: 1.05rem;
       line-height: 1.7;
-      color: rgba(255, 255, 255, 0.88);
+      color: #2774AE;
+      text-align: center;
     }
 
     main {
       max-width: 1200px;
-      margin: -2.5rem auto 4rem;
+      margin: 0 auto 4rem;
       padding: 0 1.5rem 3rem;
     }
 
@@ -233,7 +246,7 @@
     }
 
     @media (max-width: 768px) {
-      header h1 { font-size: 2rem; }
+      .header h1 { font-size: 2rem; }
       .control-row { flex-direction: column; align-items: flex-start; }
       select { width: 100%; }
       .quartile-options { width: 100%; }
@@ -241,16 +254,17 @@
   </style>
 </head>
 <body>
-  <div class="top-nav">
-    <a href="index.html">&#8592; Back to main dashboard</a>
-  </div>
-
-  <header>
-    <h1>Suspension Rates by Enrollment Quartiles</h1>
-    <p>
-      Compare how suspension rates shift across campuses with different racial/ethnic enrollment concentrations.
-      Select a student group, choose which quartiles to display, and see how the rates evolve over time and in the most recent year.
-    </p>
+  <header class="header">
+    <div class="container">
+      <div class="header-top">
+        <a class="nav-link" href="index.html">&#8592; Back to main dashboard</a>
+      </div>
+      <h1>Suspension Rates by Enrollment Quartiles</h1>
+      <p>
+        Compare how suspension rates shift across campuses with different racial/ethnic enrollment concentrations.
+        Select a student group, choose which quartiles to display, and see how the rates evolve over time and in the most recent year.
+      </p>
+    </div>
   </header>
 
   <main>

--- a/race_year_rates_dashboard.html
+++ b/race_year_rates_dashboard.html
@@ -27,16 +27,22 @@
 
     body {
       margin: 0;
-      background: var(--bg);
+      background: linear-gradient(135deg, #003B5C 0%, #2774AE 100%);
       color: var(--text);
       min-height: 100vh;
     }
 
-    header {
-      background: var(--accent-strong);
-      color: #ffffff;
-      padding: 2.75rem 1.5rem 2rem;
-      box-shadow: 0 4px 18px rgba(0, 59, 92, 0.35);
+    .header {
+      background: rgba(255, 255, 255, 0.95);
+      padding: 2.75rem 0 2rem;
+      box-shadow: 0 4px 20px rgba(0, 59, 92, 0.12);
+      margin-bottom: 2.5rem;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
     }
 
     .header-top {
@@ -52,37 +58,35 @@
       gap: 0.35rem;
       font-size: 0.95rem;
       font-weight: 600;
-      color: rgba(218, 235, 254, 0.95);
+      color: #005587;
       text-decoration: none;
       padding: 0.45rem 0.85rem;
       border-radius: 999px;
-      background: rgba(0, 59, 92, 0.35);
-      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+      background: rgba(39, 116, 174, 0.14);
+      border: 1px solid rgba(39, 116, 174, 0.28);
+      transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .back-link:hover {
-      background: rgba(0, 59, 92, 0.55);
-      color: #ffffff;
+    .back-link:hover,
+    .back-link:focus-visible {
+      background: rgba(39, 116, 174, 0.24);
+      box-shadow: 0 10px 24px rgba(0, 59, 92, 0.16);
+      outline: none;
       transform: translateX(-2px);
     }
 
-    .back-link:focus-visible {
-      outline: 2px solid var(--highlight);
-      outline-offset: 3px;
-      box-shadow: 0 0 0 4px rgba(255, 184, 28, 0.3);
-    }
-
-    header h1 {
+    .header h1 {
       margin: 0;
       font-size: clamp(1.8rem, 3vw, 2.5rem);
       letter-spacing: -0.01em;
+      color: #003B5C;
     }
 
-    header p {
+    .header p {
       margin: 0.75rem 0 0;
       max-width: 60rem;
       font-size: 1rem;
-      color: rgba(218, 235, 254, 0.85);
+      color: #2774AE;
     }
 
     main {
@@ -293,16 +297,18 @@
   </style>
 </head>
 <body>
-  <header>
-    <div class="header-top">
-      <a class="back-link" href="index.html">← Back to dashboard home</a>
+  <header class="header">
+    <div class="container">
+      <div class="header-top">
+        <a class="back-link" href="index.html">← Back to dashboard home</a>
+      </div>
+      <h1>Race × Year Suspension Explorer</h1>
+      <p>
+        Explore pre-computed suspension metrics from the comprehensive rates analysis. Select any
+        combination of academic years and race/ethnicity groups, then update the charts and summary to
+        review total suspensions and rate comparisons.
+      </p>
     </div>
-    <h1>Race × Year Suspension Explorer</h1>
-    <p>
-      Explore pre-computed suspension metrics from the comprehensive rates analysis. Select any
-      combination of academic years and race/ethnicity groups, then update the charts and summary to
-      review total suspensions and rate comparisons.
-    </p>
   </header>
   <main>
     <div id="loading">Loading pre-computed data…</div>

--- a/suspension_categories_dashboard.html
+++ b/suspension_categories_dashboard.html
@@ -28,31 +28,37 @@
 
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background-color: var(--background);
+            background: linear-gradient(135deg, #003B5C 0%, #2774AE 100%);
             color: var(--text-primary);
             line-height: 1.6;
+            min-height: 100vh;
         }
 
         .header {
-            background: linear-gradient(135deg, var(--ucla-blue), var(--ucla-darker-blue));
-            color: white;
-            padding: 2rem 0;
+            background: rgba(255, 255, 255, 0.95);
+            padding: 2.5rem 0;
+            box-shadow: 0 4px 20px rgba(0, 59, 92, 0.12);
+            margin-bottom: 2.5rem;
+        }
+
+        .header .container {
             text-align: center;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            padding: 0 1rem;
         }
 
         .header h1 {
             font-size: 2.5rem;
             font-weight: 700;
             margin-bottom: 0.5rem;
+            color: #003B5C;
         }
 
         .header p {
             font-size: 1.1rem;
-            opacity: 0.9;
             max-width: 800px;
             margin: 0 auto;
             padding: 0 1rem;
+            color: #2774AE;
         }
 
         .container {
@@ -200,10 +206,12 @@
     </style>
 </head>
 <body>
-    <div class="header">
-        <h1>Suspension Categories Trends</h1>
-        <p>Explore how different types of school suspensions have changed over time across various student populations and school settings</p>
-    </div>
+    <header class="header">
+        <div class="container">
+            <h1>Suspension Categories Trends</h1>
+            <p>Explore how different types of school suspensions have changed over time across various student populations and school settings</p>
+        </div>
+    </header>
 
     <div class="container">
         <div class="controls-panel">

--- a/tail_concentration_dashboard.html
+++ b/tail_concentration_dashboard.html
@@ -25,33 +25,39 @@
 
     body {
       margin: 0;
-      background: var(--bg);
+      background: linear-gradient(135deg, #003B5C 0%, #2774AE 100%);
       color: var(--text);
       min-height: 100vh;
     }
 
-    header {
-      background: var(--accent-strong);
-      color: #ffffff;
-      padding: 2.5rem 1.5rem 2rem;
-      box-shadow: 0 4px 18px rgba(0, 59, 92, 0.35);
+    .header {
+      background: rgba(255, 255, 255, 0.95);
+      padding: 2.5rem 0 2rem;
+      box-shadow: 0 4px 20px rgba(0, 59, 92, 0.12);
+      margin-bottom: 2.5rem;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
     }
 
     .header-top {
       display: flex;
       align-items: center;
-      justify-content: flex-start;
+      justify-content: space-between;
       gap: 1rem;
       margin-bottom: 1.5rem;
+      flex-wrap: wrap;
     }
 
     .methodology-button {
-      margin-left: auto;
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
       border: none;
-      background: var(--highlight);
+      background: linear-gradient(90deg, #FFD100, #FFC72C);
       color: var(--accent-strong);
       font-weight: 600;
       padding: 0.55rem 1.1rem;
@@ -59,18 +65,15 @@
       cursor: pointer;
       transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
       text-decoration: none;
+      box-shadow: 0 10px 24px rgba(0, 59, 92, 0.18);
     }
 
-    .methodology-button:hover {
-      background: #ffc85b;
-      box-shadow: 0 8px 18px rgba(0, 59, 92, 0.25);
-      transform: translateY(-1px);
-    }
-
+    .methodology-button:hover,
     .methodology-button:focus-visible {
-      outline: 2px solid #ffd277;
-      outline-offset: 3px;
-      box-shadow: 0 0 0 4px rgba(255, 184, 28, 0.35);
+      background: linear-gradient(90deg, #FFE066, #FFD54F);
+      box-shadow: 0 12px 28px rgba(0, 59, 92, 0.22);
+      outline: none;
+      transform: translateY(-1px);
     }
 
     .back-link {
@@ -79,37 +82,35 @@
       gap: 0.35rem;
       font-size: 0.95rem;
       font-weight: 600;
-      color: rgba(218, 235, 254, 0.95);
+      color: #005587;
       text-decoration: none;
       padding: 0.45rem 0.85rem;
       border-radius: 999px;
-      background: rgba(0, 59, 92, 0.35);
-      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+      background: rgba(39, 116, 174, 0.14);
+      border: 1px solid rgba(39, 116, 174, 0.28);
+      transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .back-link:hover {
-      background: rgba(0, 59, 92, 0.55);
-      color: #ffffff;
+    .back-link:hover,
+    .back-link:focus-visible {
+      background: rgba(39, 116, 174, 0.24);
+      box-shadow: 0 10px 24px rgba(0, 59, 92, 0.16);
+      outline: none;
       transform: translateX(-2px);
     }
 
-    .back-link:focus-visible {
-      outline: 2px solid var(--highlight);
-      outline-offset: 3px;
-      box-shadow: 0 0 0 4px rgba(255, 184, 28, 0.3);
-    }
-
-    header h1 {
+    .header h1 {
       margin: 0;
       font-size: clamp(1.8rem, 3vw, 2.4rem);
       letter-spacing: -0.01em;
+      color: #003B5C;
     }
 
-    header p {
+    .header p {
       margin: 0.75rem 0 0;
       max-width: 60rem;
       font-size: 1rem;
-      color: rgba(218, 235, 254, 0.85);
+      color: #2774AE;
     }
 
     main {
@@ -349,19 +350,21 @@
   </style>
 </head>
 <body>
-  <header>
-    <div class="header-top">
-      <a class="back-link" href="index.html">← Back to dashboard home</a>
-      <a class="methodology-button" href="#methodology-and-filters">
-        Methodology &amp; filters
-      </a>
+  <header class="header">
+    <div class="container">
+      <div class="header-top">
+        <a class="back-link" href="index.html">← Back to dashboard home</a>
+        <a class="methodology-button" href="#methodology-and-filters">
+          Methodology &amp; filters
+        </a>
+      </div>
+      <h1>Tail Concentration Explorer</h1>
+      <p>
+        Use the controls below to surface the existing grade-setting outputs produced by the REACH suspension
+        analyses. Toggle grade levels and school types to see the prepared results without running any new
+        computations.
+      </p>
     </div>
-    <h1>Tail Concentration Explorer</h1>
-    <p>
-      Use the controls below to surface the existing grade-setting outputs produced by the REACH suspension
-      analyses. Toggle grade levels and school types to see the prepared results without running any new
-      computations.
-    </p>
   </header>
   <main>
     <div id="loading">Loading pre-computed data…</div>


### PR DESCRIPTION
## Summary
- update every dashboard to use the same UCLA gradient background and translucent white header used on the suspension dashboard
- wrap header content in shared container layouts and refresh navigation/back links for visual consistency
- retune call-to-action styling (e.g., methodology pill) so buttons remain legible against the unified header treatment

## Testing
- not run (HTML change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6e87dad6c8331aefd9b6aaa77ddf9