### PR TITLE
Set Willful Defiance trend lines to red dashed styling

### DIFF
--- a/graph_scripts/20_suspension_reason_trends_by_level_and_locale.py
+++ b/graph_scripts/20_suspension_reason_trends_by_level_and_locale.py
@@ -60,7 +60,7 @@ REASON_PALETTE = {
     "Violent (No Injury)": UCLA_PALETTE["Darker Blue"],
     "Weapons": UCLA_PALETTE["UCLA Blue"],
     "Illicit Drugs": UCLA_PALETTE["Purple"],
-    "Willful Defiance": UCLA_PALETTE["Green"],
+    "Willful Defiance": "red",
     "Other": UCLA_PALETTE["Magenta"],
 }
 
@@ -299,7 +299,17 @@ def plot_level_locale(
         reason_df = reason_df.sort_values("academic_year")
         xs = [x_positions[year] for year in reason_df["academic_year"]]
         ys = reason_df["rate"].to_numpy() * 100
-        ax.plot(xs, ys, label=reason_label, color=color, linewidth=2.2, marker="o", markersize=6)
+        linestyle = "--" if reason_label == "Willful Defiance" else "-"
+        ax.plot(
+            xs,
+            ys,
+            label=reason_label,
+            color=color,
+            linewidth=2.2,
+            marker="o",
+            markersize=6,
+            linestyle=linestyle,
+        )
         for x_val, y_val, rate_val in zip(xs, ys, reason_df["rate"]):
             label = _format_percent(rate_val)
             text = ax.text(
@@ -401,7 +411,17 @@ def plot_statewide(
         reason_df = reason_df.sort_values("academic_year")
         xs = [x_positions[year] for year in reason_df["academic_year"]]
         ys = reason_df["rate"].to_numpy() * 100
-        ax.plot(xs, ys, label=reason_label, color=color, linewidth=2.2, marker="o", markersize=6)
+        linestyle = "--" if reason_label == "Willful Defiance" else "-"
+        ax.plot(
+            xs,
+            ys,
+            label=reason_label,
+            color=color,
+            linewidth=2.2,
+            marker="o",
+            markersize=6,
+            linestyle=linestyle,
+        )
         for x_val, y_val, rate_val in zip(xs, ys, reason_df["rate"]):
             label = _format_percent(rate_val)
             text = ax.text(

--- a/graph_scripts/20_suspension_reason_trends_ucla.py
+++ b/graph_scripts/20_suspension_reason_trends_ucla.py
@@ -26,6 +26,7 @@ UCLA_BLUE = "#2774AE"
 UCLA_DARKEST_GOLD = "#FFB81C"
 UCLA_DARKER_GOLD = "#8A69D4"
 UCLA_GOLD = "#FFD100"
+RED = "red"
 UCLA_LIGHTEST_BLUE = "#8BB8E8"
 
 TEXT_COLOR = UCLA_DARKEST_BLUE
@@ -45,7 +46,7 @@ REASON_PALETTE = {
     "Violent (No Injury)": UCLA_DARKER_BLUE,
     "Weapons": UCLA_BLUE,
     "Illicit Drugs": UCLA_DARKEST_GOLD,
-    "Willful Defiance": UCLA_DARKER_GOLD,
+    "Willful Defiance": RED,
     "Other": UCLA_GOLD,
 }
 
@@ -169,7 +170,17 @@ def plot_level(
         reason_df = reason_df.sort_values("academic_year")
         xs = [x_positions[year] for year in reason_df["academic_year"]]
         ys = reason_df["rate"].to_numpy() * 100
-        ax.plot(xs, ys, label=reason_label, color=color, linewidth=2.2, marker="o", markersize=6)
+        linestyle = "--" if reason_label == "Willful Defiance" else "-"
+        ax.plot(
+            xs,
+            ys,
+            label=reason_label,
+            color=color,
+            linewidth=2.2,
+            marker="o",
+            markersize=6,
+            linestyle=linestyle,
+        )
         for x_val, y_val, rate_val in zip(xs, ys, reason_df["rate"]):
             label = _format_percent(rate_val)
             text = ax.text(


### PR DESCRIPTION
## Summary
- update Willful Defiance palette entries to use red for the UCLA suspension trend graphs
- render Willful Defiance time series with a dashed line so it stands out in line charts

## Testing
- python -m compileall graph_scripts/20_suspension_reason_trends_by_level_and_locale.py graph_scripts/20_suspension_reason_trends_ucla.py

------
https://chatgpt.com/codex/tasks/task_e_68dcb0bd87c883319882f7f064ec9078