### PR TITLE
Share universal UCLA discipline palette across trend charts

### DIFF
--- a/graph_scripts/20_suspension_reason_trends_by_level_and_locale.py
+++ b/graph_scripts/20_suspension_reason_trends_by_level_and_locale.py
@@ -28,23 +28,10 @@ import pandas as pd
 import pyarrow.parquet as pq
 from adjustText import adjust_text
 
-# UCLA brand-aligned palette
-UCLA_PALETTE = {
-    "Darkest Blue": "#003B5C",
-    "Darker Blue": "red",
-    "UCLA Blue": "#2774AE",
-    "Lighter Blue": "#8BB8E8",
-    "UCLA Gold": "#FFD100",
-    "Darker Gold": "#FFC72C",
-    "Darkest Gold": "#FFB81C",
-    "Purple": "#8A69D4",
-    "Green": "#00FF87",
-    "Magenta": "#FF00A5",
-    "Cyan": "#00FFFF",
-}
+from palette_utils import DISCIPLINE_BASE_PALETTE, DISCIPLINE_REASON_PALETTE
 
-TEXT_COLOR = UCLA_PALETTE["Darkest Blue"]
-GRID_COLOR = UCLA_PALETTE["Lighter Blue"]
+TEXT_COLOR = DISCIPLINE_BASE_PALETTE["Darkest Blue"]
+GRID_COLOR = DISCIPLINE_BASE_PALETTE["Lighter Blue"]
 
 REASON_COLUMNS = {
     "suspension_count_violent_incident_injury": "Violent (Injury)",
@@ -55,14 +42,7 @@ REASON_COLUMNS = {
     "suspension_count_other_reasons": "Other",
 }
 
-REASON_PALETTE = {
-    "Violent (Injury)": UCLA_PALETTE["Darkest Blue"],
-    "Violent (No Injury)": UCLA_PALETTE["Darker Blue"],
-    "Weapons": UCLA_PALETTE["UCLA Blue"],
-    "Illicit Drugs": UCLA_PALETTE["Purple"],
-    "Willful Defiance": "red",
-    "Other": UCLA_PALETTE["Magenta"],
-}
+REASON_PALETTE = DISCIPLINE_REASON_PALETTE.copy()
 
 LEVEL_ORDER = ["Elementary", "Middle", "High"]
 LOCALE_COLUMN = "locale_simple"

--- a/graph_scripts/20_suspension_reason_trends_ucla.py
+++ b/graph_scripts/20_suspension_reason_trends_ucla.py
@@ -19,18 +19,10 @@ import pandas as pd
 import pyarrow.parquet as pq
 from adjustText import adjust_text
 
-# UCLA brand colors
-UCLA_DARKEST_BLUE = "#003B5C"
-UCLA_DARKER_BLUE = "red" 
-UCLA_BLUE = "#2774AE"
-UCLA_DARKEST_GOLD = "#FFB81C"
-UCLA_DARKER_GOLD = "#8A69D4"
-UCLA_GOLD = "#FFD100"
-RED = "red"
-UCLA_LIGHTEST_BLUE = "#8BB8E8"
+from palette_utils import DISCIPLINE_BASE_PALETTE, DISCIPLINE_REASON_PALETTE
 
-TEXT_COLOR = UCLA_DARKEST_BLUE
-GRID_COLOR = UCLA_LIGHTEST_BLUE
+TEXT_COLOR = DISCIPLINE_BASE_PALETTE["Darkest Blue"]
+GRID_COLOR = DISCIPLINE_BASE_PALETTE["Lighter Blue"]
 
 REASON_COLUMNS = {
     "suspension_count_violent_incident_injury": "Violent (Injury)",
@@ -41,14 +33,7 @@ REASON_COLUMNS = {
     "suspension_count_other_reasons": "Other",
 }
 
-REASON_PALETTE = {
-    "Violent (Injury)": UCLA_DARKEST_BLUE,
-    "Violent (No Injury)": UCLA_DARKER_BLUE,
-    "Weapons": UCLA_BLUE,
-    "Illicit Drugs": UCLA_DARKEST_GOLD,
-    "Willful Defiance": RED,
-    "Other": UCLA_GOLD,
-}
+REASON_PALETTE = DISCIPLINE_REASON_PALETTE.copy()
 
 LEVEL_ORDER = ["Elementary", "Middle", "High"]
 

--- a/graph_scripts/palette_utils.py
+++ b/graph_scripts/palette_utils.py
@@ -1,0 +1,37 @@
+"""Shared UCLA-aligned color palettes for discipline graphics."""
+
+DISCIPLINE_BASE_PALETTE = {
+    "Darkest Blue": "#003B5C",
+    "Darker Blue": "#005587",
+    "UCLA Blue": "#2774AE",
+    "Lighter Blue": "#8BB8E8",
+    "UCLA Gold": "#FFD100",
+    "Darker Gold": "#FFC72C",
+    "Darkest Gold": "#FFB81C",
+    "Purple": "#8A69D4",
+    "Magenta": "#FF00A5",
+    "Cyan": "#00FFFF",
+}
+
+# Prefer distinctive non-UCLA accent colors before reusing darker/lighter variants.
+DISCIPLINE_COLOR_PRIORITY = [
+    "UCLA Blue",
+    "UCLA Gold",
+    "Magenta",
+    "Cyan",
+    "Purple",
+    "Darker Blue",
+    "Darkest Blue",
+    "Lighter Blue",
+    "Darker Gold",
+    "Darkest Gold",
+]
+
+DISCIPLINE_REASON_PALETTE = {
+    "Violent (Injury)": DISCIPLINE_BASE_PALETTE["UCLA Blue"],
+    "Violent (No Injury)": DISCIPLINE_BASE_PALETTE["Magenta"],
+    "Weapons": DISCIPLINE_BASE_PALETTE["Cyan"],
+    "Illicit Drugs": DISCIPLINE_BASE_PALETTE["Purple"],
+    "Willful Defiance": "red",
+    "Other": DISCIPLINE_BASE_PALETTE["UCLA Gold"],
+}


### PR DESCRIPTION
## Summary
- add a shared UCLA-aligned discipline palette module for reuse across suspension reason scripts
- update the UCLA trend scripts to draw colors from the shared palette while keeping Willful Defiance red and dashed

## Testing
- python -m compileall graph_scripts/20_suspension_reason_trends_by_level_and_locale.py graph_scripts/20_suspension_reason_trends_ucla.py

------
https://chatgpt.com/codex/tasks/task_e_68dcb3699af08331ae0a5b1bf4060c5a