### PR TITLE
Fix palette_utils import when running suspension reason charts in RStudio

### DIFF
--- a/graph_scripts/20_suspension_reason_trends_ucla.py
+++ b/graph_scripts/20_suspension_reason_trends_ucla.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import math
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -18,6 +19,16 @@ import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 from adjustText import adjust_text
+
+
+# ``palette_utils`` lives alongside this script.  When the module is executed via
+# ``reticulate::source_python()`` in RStudio, Python's module search path does
+# not automatically include the script directory, which caused
+# ``ModuleNotFoundError`` for ``palette_utils``.  Explicitly add the current
+# directory so the shared palette definitions can always be imported.
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
 from palette_utils import DISCIPLINE_BASE_PALETTE, DISCIPLINE_REASON_PALETTE
 


### PR DESCRIPTION
## Summary
- ensure the script directory is added to `sys.path` before importing `palette_utils`
- document why the adjustment is necessary when sourcing the script via reticulate

## Testing
- python graph_scripts/20_suspension_reason_trends_ucla.py --data-path data-stage/susp_v6_long.parquet --output-dir /tmp/test_output --image-format png --dpi 72

------
https://chatgpt.com/codex/tasks/task_e_68dd151b7268833186e17f41b24d86e5