### PR TITLE
Fix legend icons for quartile comparison plots

### DIFF
--- a/graph_scripts/07_quartile_enrollment_comparison.R
+++ b/graph_scripts/07_quartile_enrollment_comparison.R
@@ -147,7 +147,8 @@ build_quartile_plot <- function(data, panel_label = NULL) {
       box.padding = grid::unit(0.3, "lines"),
       point.padding = grid::unit(0.3, "lines"),
       min.segment.length = 0,
-      max.overlaps = Inf
+      max.overlaps = Inf,
+      show.legend = FALSE
     ) +
 
     scale_color_manual(


### PR DESCRIPTION
## Summary
- prevent the data label layer from contributing legend keys so the legend uses solid color swatches again

## Testing
- not run (data-dependent script)


------
https://chatgpt.com/codex/tasks/task_e_68dd303ed1288331a43a1b597286a31a