### PR TITLE
Fix label prep in Black quartile suspension trends script

### DIFF
--- a/graph_scripts/21_black_quartile_suspension_trends.R
+++ b/graph_scripts/21_black_quartile_suspension_trends.R
@@ -6,21 +6,24 @@ suppressPackageStartupMessages({
   library(ggplot2)
   library(glue)
   library(here)
+  library(ggrepel)
   library(readr)
   library(scales)
+  library(tidyr)
 })
 
 source(here::here("graph_scripts", "graph_utils.R"))
 
 quartile_palette <- c(
-  "Q1" = "#0B3954",
-  "Q2" = "#087E8B",
-  "Q3" = "#FF5A5F",
-  "Q4" = "#C81D25"
+  'Q1' = '#003B5C',  # Darkest Blue
+  'Q2' = '#2774AE',  # UCLA Blue
+  'Q3' = '#FFC72C',  # Darker Gold
+  'Q4' = '#8A69D4'   # Purple accent keeps high-contrast separation
 )
 
-statewide_color <- "#D00000"
-statewide_label <- "Statewide Traditional Average"
+statewide_color <- 'red'  # Matches the Willful Defiance accent in palette_utils.py
+statewide_linetype <- 'dashed'
+statewide_label <- 'Statewide average (All Students)'
 
 joined <- load_joined_data()
 
@@ -38,19 +41,43 @@ if (nrow(black_base) == 0) {
   stop("No traditional school records available for Black student quartile trends.")
 }
 
-statewide_rates <- black_base %>%
+all_students_base <- joined %>%
+  dplyr::filter(
+    is_traditional,
+    subgroup == "All Students",
+    !is.na(total_suspensions),
+    !is.na(cumulative_enrollment),
+    cumulative_enrollment > 0
+  ) %>%
+  dplyr::mutate(academic_year = as.character(academic_year))
+
+if (nrow(all_students_base) == 0) {
+  stop("No statewide All Students records available for traditional schools.")
+}
+
+year_levels <- union(black_base$academic_year, all_students_base$academic_year) %>%
+  unique() %>%
+  sort()
+
+statewide_rates <- all_students_base %>%
   dplyr::group_by(academic_year) %>%
   dplyr::summarise(
     suspensions = sum(total_suspensions, na.rm = TRUE),
     enrollment = sum(cumulative_enrollment, na.rm = TRUE),
     rate = safe_div(suspensions, enrollment),
     .groups = "drop"
-  )
+  ) %>%
+  dplyr::mutate(
+    academic_year = factor(academic_year, levels = year_levels, ordered = TRUE)
+  ) %>%
+  dplyr::arrange(academic_year)
 
-year_levels <- statewide_rates$academic_year %>% unique() %>% sort()
-
-statewide_rates <- statewide_rates %>%
-  dplyr::mutate(academic_year = factor(academic_year, levels = year_levels, ordered = TRUE))
+series_levels <- c(names(quartile_palette), statewide_label)
+series_palette <- c(quartile_palette, stats::setNames(statewide_color, statewide_label))
+series_linetypes <- c(
+  stats::setNames(rep("solid", length(quartile_palette)), names(quartile_palette)),
+  stats::setNames(statewide_linetype, statewide_label)
+)
 
 prepare_quartile_data <- function(data, quartile_col, quartile_label_col, cohort_label) {
   data %>%
@@ -67,10 +94,16 @@ prepare_quartile_data <- function(data, quartile_col, quartile_label_col, cohort
       rate = safe_div(suspensions, enrollment),
       .groups = "drop"
     ) %>%
+    tidyr::complete(
+      academic_year = year_levels,
+      tidyr::nesting(quartile, quartile_label),
+      fill = list(suspensions = NA_real_, enrollment = NA_real_, rate = NA_real_)
+    ) %>%
     dplyr::mutate(
       academic_year = factor(academic_year, levels = year_levels, ordered = TRUE),
       cohort = cohort_label
-    )
+    ) %>%
+    dplyr::arrange(academic_year)
 }
 
 black_quartiles <- prepare_quartile_data(
@@ -96,31 +129,144 @@ if (nrow(white_quartiles) == 0) {
 }
 
 build_quartile_plot <- function(quartile_data, cohort_label) {
-  ggplot() +
+  quartile_legend_labels <- quartile_data %>%
+    dplyr::filter(!is.na(quartile_label)) %>%
+    dplyr::distinct(quartile, quartile_label) %>%
+    dplyr::arrange(quartile) %>%
+    { stats::setNames(.$quartile_label, as.character(.$quartile)) }
+
+  legend_labels <- c(
+    quartile_legend_labels[names(quartile_palette)],
+    stats::setNames(statewide_label, statewide_label)
+  )
+
+  if (any(is.na(legend_labels))) {
+    missing <- is.na(legend_labels)
+    legend_labels[missing] <- names(legend_labels)[missing]
+  }
+
+  plot_data <- dplyr::bind_rows(
+    quartile_data %>%
+      dplyr::transmute(
+        academic_year = factor(as.character(academic_year), levels = year_levels, ordered = TRUE),
+        rate = rate,
+        series = as.character(quartile),
+        point_size = 2.3
+      ),
+    statewide_rates %>%
+      dplyr::transmute(
+        academic_year = factor(as.character(academic_year), levels = year_levels, ordered = TRUE),
+        rate = rate,
+        series = statewide_label,
+        point_size = 2.6
+      )
+  ) %>%
+    dplyr::mutate(
+      series = factor(series, levels = series_levels, ordered = TRUE)
+    ) %>%
+    dplyr::arrange(series, academic_year)
+
+  label_data <- plot_data %>%
+    dplyr::filter(!is.na(rate)) %>%
+    dplyr::mutate(
+      label = scales::percent(rate, accuracy = 0.1),
+      segment_colour = series_palette[as.character(series)]
+    )
+
+  quartile_labels <- label_data %>%
+    dplyr::filter(as.character(series) != statewide_label) %>%
+    dplyr::mutate(segment_linetype = "solid")
+
+  statewide_labels <- label_data %>%
+    dplyr::filter(as.character(series) == statewide_label) %>%
+    dplyr::mutate(segment_linetype = "solid")
+
+  ggplot(plot_data, aes(
+    x = academic_year,
+    y = rate,
+    group = series,
+    color = series,
+    linetype = series
+  )) +
     geom_line(
-      data = quartile_data,
-      aes(x = academic_year, y = rate, color = quartile, group = quartile),
-      linewidth = 1
+      linewidth = 1.1,
+      lineend = 'round',
+      na.rm = TRUE
     ) +
     geom_point(
-      data = quartile_data,
-      aes(x = academic_year, y = rate, color = quartile),
-      size = 2
+      aes(size = point_size),
+      stroke = 0,
+      na.rm = TRUE,
+      show.legend = FALSE
     ) +
-    geom_line(
-      data = statewide_rates,
-      aes(x = academic_year, y = rate, color = statewide_label, group = statewide_label),
-      linewidth = 1
+    scale_size_identity() +
+    ggrepel::geom_label_repel(
+      data = quartile_labels,
+      aes(
+        x = academic_year,
+        y = rate,
+        label = label,
+        color = series,
+        segment.colour = segment_colour,
+        segment.linetype = segment_linetype
+      ),
+      inherit.aes = FALSE,
+      fill = scales::alpha("white", 0.85),
+      fontface = "bold",
+      size = 3,
+      show.legend = FALSE,
+      label.size = 0,
+      label.padding = grid::unit(0.18, "lines"),
+      box.padding = grid::unit(0.35, "lines"),
+      point.padding = grid::unit(0.3, "lines"),
+      label.r = grid::unit(0.08, "lines"),
+      direction = "y",
+      max.overlaps = Inf,
+      segment.size = 0.4,
+      min.segment.length = 0
     ) +
-    geom_point(
-      data = statewide_rates,
-      aes(x = academic_year, y = rate, color = statewide_label),
-      size = 2
+    ggrepel::geom_label_repel(
+      data = statewide_labels,
+      aes(
+        x = academic_year,
+        y = rate,
+        label = label,
+        color = series,
+        segment.colour = segment_colour,
+        segment.linetype = segment_linetype
+      ),
+      inherit.aes = FALSE,
+      fill = scales::alpha("white", 0.85),
+      fontface = "bold",
+      size = 3,
+      show.legend = FALSE,
+      label.size = 0,
+      label.padding = grid::unit(0.18, "lines"),
+      box.padding = grid::unit(0.35, "lines"),
+      point.padding = grid::unit(0.3, "lines"),
+      label.r = grid::unit(0.08, "lines"),
+      direction = "y",
+      max.overlaps = Inf,
+      segment.size = 0.4,
+      min.segment.length = 0
     ) +
     scale_color_manual(
-      values = c(quartile_palette, setNames(statewide_color, statewide_label)),
-      breaks = c(names(quartile_palette), statewide_label),
-      name = "Series"
+      values = series_palette,
+      breaks = series_levels,
+      labels = unname(legend_labels),
+      name = "Series",
+      guide = guide_legend(
+        override.aes = list(
+          linetype = unname(series_linetypes),
+          linewidth = rep(1.1, length(series_levels))
+        )
+      )
+    ) +
+    scale_linetype_manual(
+      values = series_linetypes,
+      breaks = series_levels,
+      labels = unname(legend_labels),
+      guide = "none"
     ) +
     scale_y_continuous(labels = scales::percent_format(accuracy = 0.1)) +
     labs(


### PR DESCRIPTION
## Summary
- precompute quartile and statewide label tables so geom_label_repel has defined data sources
- keep the all-students statewide overlay tied to the Willful Defiance styling while reusing the common palette metadata for legend mapping

## Testing
- Not run (Rscript unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd90e99f2083318e75a7627c6568f9