### PR TITLE
Fix label prep in Black quartile suspension trends script (follow-up)

### DIFF
--- a/graph_scripts/21_black_quartile_suspension_trends.R
+++ b/graph_scripts/21_black_quartile_suspension_trends.R
@@ -96,11 +96,12 @@ prepare_quartile_data <- function(data, quartile_col, quartile_label_col, cohort
     ) %>%
     tidyr::complete(
       academic_year = year_levels,
-      tidyr::nesting(quartile, quartile_label),
+      quartile = factor(names(quartile_palette), levels = names(quartile_palette), ordered = TRUE),
       fill = list(suspensions = NA_real_, enrollment = NA_real_, rate = NA_real_)
     ) %>%
     dplyr::mutate(
       academic_year = factor(academic_year, levels = year_levels, ordered = TRUE),
+      quartile = factor(quartile, levels = names(quartile_palette), ordered = TRUE),
       cohort = cohort_label
     ) %>%
     dplyr::arrange(academic_year)


### PR DESCRIPTION
## Summary
- precompute quartile and statewide label tables so geom_label_repel has defined data sources
- keep the all-students statewide overlay tied to the Willful Defiance styling while reusing the common palette metadata for legend mapping
- complete quartile trend data only on academic year and quartile so labels stay aligned with their actual years

## Testing
- Not run (Rscript unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ddf39dc63c8331be7476f7d416f98f