### PR TITLE
Fix suspension dashboard syntax error

### DIFF
--- a/suspension_dashboard.html
+++ b/suspension_dashboard.html
@@ -481,12 +481,6 @@
         }
 
 
-            gradeSetting: [],
-            comparison: [],
-            pareto: []
-        };
-
-
         // Global chart storage
         let allCharts = {};
         let currentFilters = { year: 'all', level: 'all' };


### PR DESCRIPTION
## Summary
- add a shared `data_sources` helper and a Python builder that emits the suspension overview JSON/JS bundle
- refactor the tail concentration payload builder to reuse the shared loader
- update the suspension dashboard to fetch generated data with JSON/JS fallbacks and refresh supporting assets
- remove the stray object fragment after `showLoadError` so the dashboard script parses correctly

## Testing
- python dashboard/build_suspension_overview.py

------
https://chatgpt.com/codex/tasks/task_e_68df51debc9c833181eda9c5bd5e6309