### PR TITLE
Align dashboard quartile handling with statewide analysis

### DIFF
--- a/dashboard/build_dashboard_data.py
+++ b/dashboard/build_dashboard_data.py
@@ -48,8 +48,14 @@ prevent front-end errors.
 
 from __future__ import annotations
 
+import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
 
 # -------- Robust project root resolution --------------------------------------
 def resolve_project_root() -> Path:
@@ -93,6 +99,8 @@ DIMENSION_COLUMNS: list[str] = [
 SCHOOL_IDENTIFIER = "school_code"
 REASON_COLUMN = "reason_lab"
 
+SPECIAL_SCHOOL_CODES = {"0000000", "0000001"}
+
 # Numeric columns aggregated in the dashboard.
 NUMERIC_COLUMNS: list[str] = [
     "total_suspensions",
@@ -118,6 +126,30 @@ class AggregatedData:
 # Data preparation helpers
 # ---------------------------------------------------------------------------
 
+
+def standardize_quartile_label(series: pd.Series, group: str) -> pd.Series:
+    """Return quartile labels that match the statewide trends script."""
+
+    working = pd.Series(series, copy=False).astype("string")
+    stripped = working.str.strip()
+    result = stripped.copy()
+    result[stripped.isna() | (stripped == "")] = pd.NA
+    lowered = stripped.str.lower()
+    mask = lowered.isin({"unknown", "na"})
+    result[mask] = pd.NA
+
+    mask = lowered.str.startswith("q1") | (lowered == "1")
+    result[mask] = f"Q1 (Lowest % {group})"
+    mask = lowered.str.startswith("q2") | (lowered == "2")
+    result[mask] = "Q2"
+    mask = lowered.str.startswith("q3") | (lowered == "3")
+    result[mask] = "Q3"
+    mask = lowered.str.startswith("q4") | (lowered == "4")
+    result[mask] = f"Q4 (Highest % {group})"
+
+    return result.astype("string")
+
+
 def read_source(long_path: Path, features_path: Path, columns: Sequence[str]) -> pd.DataFrame:
     """Load the long-form parquet file and join features for locale and quartiles.
 
@@ -132,6 +164,16 @@ def read_source(long_path: Path, features_path: Path, columns: Sequence[str]) ->
     # Load the long-form suspension data
     long_df = pd.read_parquet(long_path, columns=list(columns))
 
+    if "academic_year" in long_df.columns:
+        long_df["academic_year"] = long_df["academic_year"].astype("string")
+    if SCHOOL_IDENTIFIER in long_df.columns:
+        long_df[SCHOOL_IDENTIFIER] = (
+            long_df[SCHOOL_IDENTIFIER]
+            .astype("string")
+            .str.strip()
+            .str.zfill(7)
+        )
+
     # Attempt to join locale information
     if features_path.exists():
         try:
@@ -140,7 +182,12 @@ def read_source(long_path: Path, features_path: Path, columns: Sequence[str]) ->
                 columns=[SCHOOL_IDENTIFIER, "academic_year", "locale_simple"],
             )
             feats["academic_year"] = feats["academic_year"].astype("string")
-            feats[SCHOOL_IDENTIFIER] = feats[SCHOOL_IDENTIFIER].astype("string")
+            feats[SCHOOL_IDENTIFIER] = (
+                feats[SCHOOL_IDENTIFIER]
+                .astype("string")
+                .str.strip()
+                .str.zfill(7)
+            )
             long_df = long_df.merge(
                 feats, on=[SCHOOL_IDENTIFIER, "academic_year"], how="left"
             )
@@ -149,6 +196,19 @@ def read_source(long_path: Path, features_path: Path, columns: Sequence[str]) ->
             long_df["locale_simple"] = np.nan
     else:
         long_df["locale_simple"] = np.nan
+
+    if SCHOOL_IDENTIFIER in long_df.columns:
+        long_df = long_df[~long_df[SCHOOL_IDENTIFIER].isin(SPECIAL_SCHOOL_CODES)]
+
+    quartile_columns = {
+        "black_prop_q_label": "Black",
+        "white_prop_q_label": "White",
+        "hispanic_prop_q_label": "Hispanic/Latino",
+    }
+    for column, group in quartile_columns.items():
+        if column in long_df.columns:
+            long_df[column] = standardize_quartile_label(long_df[column], group)
+
     return long_df
 
 

--- a/dashboard/build_rates_by_race_year.py
+++ b/dashboard/build_rates_by_race_year.py
@@ -103,27 +103,26 @@ def canon_race_label(series: pd.Series) -> pd.Series:
     return mapped
 
 
-def norm_quartile(series: pd.Series) -> pd.Series:
+def norm_quartile(series: pd.Series, group: str) -> pd.Series:
+    """Normalise quartile labels while retaining descriptive text."""
+
     mapping = {
-        "Q1": "Q1",
-        "1": "Q1",
+        "Q1": f"Q1 (Lowest % {group})",
+        "1": f"Q1 (Lowest % {group})",
         "Q2": "Q2",
         "2": "Q2",
         "Q3": "Q3",
         "3": "Q3",
-        "Q4": "Q4",
-        "4": "Q4",
-        "Q1 (Lowest % Black)": "Q1",
-        "Q1 (Lowest % White)": "Q1",
-        "Q1 (Lowest % Hispanic/Latino)": "Q1",
-        "Q4 (Highest % Black)": "Q4",
-        "Q4 (Highest % White)": "Q4",
-        "Q4 (Highest % Hispanic/Latino)": "Q4",
+        "Q4": f"Q4 (Highest % {group})",
+        "4": f"Q4 (Highest % {group})",
+        f"Q1 (Lowest % {group})": f"Q1 (Lowest % {group})",
+        f"Q4 (Highest % {group})": f"Q4 (Highest % {group})",
     }
-    values = series.astype("string")
+    values = series.astype("string").str.strip()
     # Preserve missing values instead of converting to the string "<NA>"
     values = values.where(~values.isna(), other=np.nan)
-    return values.map(mapping)
+    mapped = values.map(mapping)
+    return mapped.astype("string")
 
 
 def safe_div(numer: pd.Series, denom: pd.Series) -> pd.Series:
@@ -149,14 +148,19 @@ def load_long_form() -> pd.DataFrame:
     ]
     df = pd.read_parquet(LONG_PATH, columns=cols)
     for code_col, width in ("county_code", 2), ("district_code", 5), ("school_code", 7):
-        df[code_col] = df[code_col].astype("string").str.zfill(width)
+        df[code_col] = (
+            df[code_col]
+            .astype("string")
+            .str.strip()
+            .str.zfill(width)
+        )
     df["aggregate_level"] = df["aggregate_level"].astype("string")
     df = df[df["aggregate_level"].str.lower().isin({"s", "school"})]
     df = df[~df["school_code"].isin(SPECIAL_SCHOOL_CODES)]
     df["race_ethnicity"] = canon_race_label(df["subgroup"])
-    df["white_q"] = norm_quartile(df["white_prop_q_label"])
-    df["black_q"] = norm_quartile(df["black_prop_q_label"])
-    df["hispanic_q"] = norm_quartile(df["hispanic_prop_q_label"])
+    df["white_q"] = norm_quartile(df["white_prop_q_label"], "White")
+    df["black_q"] = norm_quartile(df["black_prop_q_label"], "Black")
+    df["hispanic_q"] = norm_quartile(df["hispanic_prop_q_label"], "Hispanic/Latino")
     df["enrollment"] = pd.to_numeric(df["cumulative_enrollment"], errors="coerce")
     df["total_suspensions"] = pd.to_numeric(df["total_suspensions"], errors="coerce")
     df["undup_suspensions"] = pd.to_numeric(
@@ -185,7 +189,12 @@ def load_traditional_flags() -> pd.DataFrame:
     feats = pd.read_parquet(
         FEATURES_PATH, columns=["school_code", "academic_year", "is_traditional"]
     )
-    feats["school_code"] = feats["school_code"].astype("string").str.zfill(7)
+    feats["school_code"] = (
+        feats["school_code"]
+        .astype("string")
+        .str.strip()
+        .str.zfill(7)
+    )
     feats["year"] = feats["academic_year"].astype("string")
     feats["is_traditional"] = feats["is_traditional"].fillna(False)
     feats = feats.drop(columns=["academic_year"])


### PR DESCRIPTION
## Summary
- standardize quartile labels in the dashboard build script to match statewide trend logic and drop special school codes after normalizing identifiers
- normalize quartile labels in the race-by-year builder so filters remain scoped to the correct quartiles and trim/zero-fill school codes across joins
- ensure feature joins and traditional flag lookups strip and pad school codes consistently before aggregation

## Testing
- python -m compileall dashboard/build_dashboard_data.py dashboard/build_rates_by_race_year.py

------
https://chatgpt.com/codex/tasks/task_e_68e13bf571e0833189fad4739324ab68